### PR TITLE
Adding arbiter addition to replicaset

### DIFF
--- a/lib/puppet/type/mongodb_replset.rb
+++ b/lib/puppet/type/mongodb_replset.rb
@@ -25,6 +25,10 @@ Puppet::Type.newtype(:mongodb_replset) do
     end
   end
 
+  newproperty(:arbiter) do
+    desc "The replicaSet arbiter"
+  end
+
   autorequire(:package) do
     'mongodb'
   end


### PR DESCRIPTION
This change lets you add an arbiter to the replicaset in this way:

```
mongodb_replset { 'myrepl':
  ensure => present,
  members => ['host1', 'host2'],
  arbiter => 'arbiter_host:30000',
}
```

I'm a newbie dealing with providers and types, so probably the code is not appropriate. I had some problems like i didn't find how or when the setters of new properties are called, so to solve the issue i just called it from line 61.

I guess this is not correct, so if you can guide me about how to solve this issue, it would be great.