### PR TITLE
Adds Support for Keyfile Key

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,10 @@ Default: 100 ms
 Specify the path to a key file to store authentication information. This option
 is only useful for the connection between replica set members. Default: None
 
+#####'key'
+Specify the key contained within the keyfile. This option
+is only useful for the connection between replica set members. Default: None
+
 #####`master`
 Set to true to configure the current instance to act as master instance in a
 replication configuration. Default: False  *Note*: deprecated – use replica sets

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,7 @@ class mongodb (
   $rest            = undef,
   $slowms          = undef,
   $keyfile         = undef,
+  $key             = undef,
   $bind_ip         = undef,
   $pidfilepath     = undef
 ) inherits mongodb::params {
@@ -129,6 +130,7 @@ class mongodb (
     rest            => $rest,
     slowms          => $slowms,
     keyfile         => $keyfile,
+    key             => $key,
     bind_ip         => $bind_ip,
     pidfilepath     => $pidfilepath,
   }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -50,6 +50,7 @@ class mongodb::server (
   $rest            = undef,
   $slowms          = undef,
   $keyfile         = undef,
+  $key             = undef,
   $set_parameter   = undef,
   $syslog          = undef,
 

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -41,6 +41,7 @@ class mongodb::server::config {
   $rest            = $mongodb::server::rest
   $slowms          = $mongodb::server::slowms
   $keyfile         = $mongodb::server::keyfile
+  $key             = $mongodb::server::key
   $bind_ip         = $mongodb::server::bind_ip
   $directoryperdb  = $mongodb::server::directoryperdb
   $profile         = $mongodb::server::profile
@@ -59,6 +60,14 @@ class mongodb::server::config {
     # Exists for future compatibility and clarity.
     if $auth {
       $noauth = false
+      if $keyfile {
+        file { $keyfile:
+          content => inline_template($key),
+          owner   => $user,
+          group   => $group,
+          mode    => '0400',
+        }
+      }
     }
     else {
       $noauth = true


### PR DESCRIPTION
Previously, the module could specify a keyfile (i.e. /etc/keyfile)
but could not create the file and populate it with a key. This
patch introduces the key parameter that allows a user to specify
the key to use for keyfile-based authentication.