### PR TITLE
Fixing mongodb_user to allow for multiple users to be created with the same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ mongodb_database { testdb:
   require  => Class['mongodb::server'],
 }
 ```
+
 #####`tries`
 The maximum amount of two second tries to wait MongoDB startup. Default: 10
 
@@ -419,6 +420,17 @@ mongodb_user { testuser:
   require       => Class['mongodb::server'],
 }
 ```
+
+The title of this resource can be in one of two forms:
+
+* <name\> - e.g. "admin". This will use the title as the name parameter as below. You will be required to add a database parameter when using this title pattern.
+* <name\>:<database\> - e.g. "admin:myDb". This will split the title into two, using the first part for the name parameter, and the second as the database. You are not required to add a database parameter when using this title pattern.
+
+A mongodb_user resource is considered unique based on the combination of the name and database parameters.
+
+#####`name`
+The user name.
+
 #####`password_hash`
 Hex encoded md5 hash of "$username:mongo:$password".
 

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -12,7 +12,7 @@ Puppet::Type.newtype(:mongodb_user) do
   def self.title_patterns
    [
     [
-     # pattern 01 to parse a title of the form <user>:<database>
+     #Pattern 01 to parse a title of the form <user>:<database>
      /^(.*):(.*)$/,
      [
       [:name, lambda{|x| x} ],
@@ -20,7 +20,9 @@ Puppet::Type.newtype(:mongodb_user) do
      ]
     ],
     [
-	 # pattern 02 to parse a title of the form <user>.Note that a title in this form will require database to be passed in separately
+	 #Pattern 02 to parse a title of the form <user>
+	 #Note that a title in this form will require database to be passed in separately
+	 #Provided for backwards compatibility
      /^(.*)$/,
      [
       [:name, lambda{|x| x} ]
@@ -31,9 +33,6 @@ Puppet::Type.newtype(:mongodb_user) do
   
   newparam(:name, :namevar => true) do
     desc "The name of the user."
-	defaultto do
-      :title
-    end
   end
 
   newparam(:database, :namevar => true) do

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -9,11 +9,34 @@ Puppet::Type.newtype(:mongodb_user) do
     self[:roles] = Array(self[:roles]).sort!
   end
 
-  newparam(:name, :namevar=>true) do
+  def self.title_patterns
+   [
+    [
+     # pattern 01 to parse a title of the form <user>:<database>
+     /^(.*):(.*)$/,
+     [
+      [:name, lambda{|x| x} ],
+      [:database, lambda{|x| x} ]
+     ]
+    ],
+    [
+	 # pattern 02 to parse a title of the form <user>.Note that a title in this form will require database to be passed in separately
+     /^(.*)$/,
+     [
+      [:name, lambda{|x| x} ]
+     ]
+    ]
+   ]
+ end
+  
+  newparam(:name, :namevar => true) do
     desc "The name of the user."
+	defaultto do
+      :title
+    end
   end
 
-  newparam(:database) do
+  newparam(:database, :namevar => true) do
     desc "The user's target database."
     defaultto do
       fail("Parameter 'database' must be set")

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -32,10 +32,9 @@ define mongodb::db (
     fail("Parameter 'password_hash' or 'password' should be provided to mongodb::db.")
   }
 
-  mongodb_user { $user:
+  mongodb_user { "$user:$name":
     ensure        => present,
     password_hash => $hash,
-    database      => $name,
     roles         => $roles,
     require       => Mongodb_database[$name],
   }


### PR DESCRIPTION
Came across this issue through the following use case: using mongodb::db to create multiple databases, each with the same user name. Puppet was unable to compile catalog because it then had duplicate resources with the mongo user.

I have made the user have a composite namevar based on both name and database and have added title patterns to allow for <user> (backwards compatible) or <user>:<database>.