### PR TITLE
Add enterprise support for RedHat

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -18,6 +18,8 @@ class mongodb::globals (
   $version              = undef,
 
   $manage_package_repo  = undef,
+
+  $use_enterprise_repo  = undef,
 ) {
 
   # Setup of the repo only makes sense globally, so we are doing it here.

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -4,11 +4,18 @@ class mongodb::repo (
 ) inherits mongodb::params {
   case $::osfamily {
     'RedHat', 'Linux': {
-      $location = $::architecture ? {
-        'x86_64' => 'http://downloads-distro.mongodb.org/repo/redhat/os/x86_64/',
-        'i686'   => 'http://downloads-distro.mongodb.org/repo/redhat/os/i686/',
-        'i386'   => 'http://downloads-distro.mongodb.org/repo/redhat/os/i686/',
-        default  => undef
+      if $mongodb::globals::use_enterprise_repo == 'true' {
+        $location = 'https://repo.mongodb.com/yum/redhat/$releasever/mongodb-enterprise/stable/$basearch/'
+        $description = 'MongoDB Enterprise Repository'
+      }
+      else {
+        $location = $::architecture ? {
+          'x86_64' => 'http://downloads-distro.mongodb.org/repo/redhat/os/x86_64/',
+          'i686'   => 'http://downloads-distro.mongodb.org/repo/redhat/os/i686/',
+          'i386'   => 'http://downloads-distro.mongodb.org/repo/redhat/os/i686/',
+          default  => undef
+        }
+        $description = 'MongoDB/10gen Repository'
       }
       class { 'mongodb::repo::yum': }
     }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -4,7 +4,7 @@ class mongodb::repo (
 ) inherits mongodb::params {
   case $::osfamily {
     'RedHat', 'Linux': {
-      if $mongodb::globals::use_enterprise_repo == 'true' {
+      if $mongodb::globals::use_enterprise_repo == true {
         $location = 'https://repo.mongodb.com/yum/redhat/$releasever/mongodb-enterprise/stable/$basearch/'
         $description = 'MongoDB Enterprise Repository'
       }

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -5,7 +5,7 @@ class mongodb::repo::yum inherits mongodb::repo {
 
   if($::mongodb::repo::ensure == 'present' or $::mongodb::repo::ensure == true) {
     yumrepo { 'mongodb':
-      descr    => 'MongoDB/10gen Repository',
+      descr    => $::mongodb::repo::description,
       baseurl  => $::mongodb::repo::location,
       gpgcheck => '0',
       enabled  => '1',


### PR DESCRIPTION
This pull proposes support for Enterprise MongoDB for RedHat/CentOS. Proposed changes are made according to [MongoDB doc](http://docs.mongodb.org/manual/tutorial/install-mongodb-enterprise-on-red-hat-or-centos/).