### PR TITLE
Fix against mongodb 2.6.5 from epel

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,7 +57,12 @@ class mongodb::params inherits mongodb::globals {
         $dbpath              = '/var/lib/mongodb'
         $logpath             = '/var/log/mongodb/mongodb.log'
         $bind_ip             = pick($::mongodb::globals::bind_ip, ['127.0.0.1'])
-        $pidfilepath         = '/var/run/mongodb/mongodb.pid'
+        if ($::operatingsystem == 'fedora' and versioncmp($::operatingsystemrelease, '22') >= 0 or
+            $::operatingsystem != 'fedora' and versioncmp($::operatingsystemrelease, '7.0') >= 0) {
+          $pidfilepath         = '/var/run/mongodb/mongod.pid'
+        } else {
+          $pidfilepath         = '/var/run/mongodb/mongodb.pid'
+        }
         $fork                = true
         $journal             = true
       }


### PR DESCRIPTION
The updated version of mongodb-server in epel7 2.6.5 (resp. it's systemd
script) expects the pid file to be at /var/run/mongodb/mongod.pid