### PR TITLE
Fix the bug that new user's password_hash will be rehashed

### DIFF
--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -64,14 +64,15 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
 
       mongo_eval("db.addUser(#{user.to_json})", @resource[:database])
     else
-      user = {
-        :user => @resource[:username],
+      cmd = {
+        :createUser => @resource[:username],
         :pwd => @resource[:password_hash],
         :customData => { :createdBy => "Puppet Mongodb_user['#{@resource[:name]}']" },
-        :roles => @resource[:roles]
+        :roles => @resource[:roles],
+        :digestPassword => false,
       }
 
-      mongo_eval("db.createUser(#{user.to_json})", @resource[:database])
+      mongo_eval("db.runCommand(#{cmd.to_json})", @resource[:database])
     end
 
     @property_hash[:ensure] = :present

--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -64,15 +64,17 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
 
       mongo_eval("db.addUser(#{user.to_json})", @resource[:database])
     else
-      cmd = {
-        :createUser => @resource[:username],
-        :pwd => @resource[:password_hash],
-        :customData => { :createdBy => "Puppet Mongodb_user['#{@resource[:name]}']" },
-        :roles => @resource[:roles],
-        :digestPassword => false,
+      cmd_json=<<-EOS.gsub(/$\n/, '')
+      {
+        "createUser": "#{@resource[:username]}",
+        "pwd": "#{@resource[:password_hash]}",
+        "customData": {"createdBy": "Puppet Mongodb_user['#{@resource[:name]}']"},
+        "roles": #{@resource[:roles].to_json},
+        "digestPassword": false
       }
+      EOS
 
-      mongo_eval("db.runCommand(#{cmd.to_json})", @resource[:database])
+      mongo_eval("db.runCommand(#{cmd_json})", @resource[:database])
     end
 
     @property_hash[:ensure] = :present
@@ -98,13 +100,14 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
   end
 
   def password_hash=(value)
-    cmd = {
-        :updateUser => @resource[:username],
-        :pwd => @resource[:password_hash],
-        :digestPassword => false
+    cmd_json=<<-EOS.gsub(/$\n/, '')
+        "updateUser": "#{@resource[:username]}",
+        "pwd": "#{@resource[:password_hash]}",
+        "digestPassword": false
     }
+    EOS
 
-    mongo_eval("db.runCommand(#{cmd.to_json})", @resource[:database])
+    mongo_eval("db.runCommand(#{cmd_json})", @resource[:database])
   end
 
   def roles=(roles)

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -39,15 +39,16 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'create' do
     it 'creates a user' do
-      user = {
-        :user => 'new_user',
+      cmd = {
+        :createUser => 'new_user',
         :pwd => 'pass',
         :customData => { :createdBy => "Puppet Mongodb_user['new_user']" },
         :roles => ['role1','role2'],
+        :digestPassword => false,
       }
 
 
-      provider.expects(:mongo_eval).with("db.createUser(#{user.to_json})", 'new_database')
+      provider.expects(:mongo_eval).with("db.runCommand(#{cmd.to_json})", 'new_database')
       provider.create
     end
   end

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -39,16 +39,17 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'create' do
     it 'creates a user' do
-      cmd = {
-        :createUser => 'new_user',
-        :pwd => 'pass',
-        :customData => { :createdBy => "Puppet Mongodb_user['new_user']" },
-        :roles => ['role1','role2'],
-        :digestPassword => false,
+      cmd_json=<<-EOS.gsub(/$\n/, '')
+      {
+        "createUser": "new_user",
+        "pwd => "pass",
+        "customData": {"createdBy": "Puppet Mongodb_user['new_user']"},
+        "roles": ["role1", "role2"],
+        "digestPassword": false
       }
+      EOS
 
-
-      provider.expects(:mongo_eval).with("db.runCommand(#{cmd.to_json})", 'new_database')
+      provider.expects(:mongo_eval).with("db.runCommand(#{cmd_json})", 'new_database')
       provider.create
     end
   end
@@ -74,13 +75,15 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'password_hash=' do
     it 'changes a password_hash' do
-      cmd = {
-          :updateUser => 'new_user',
-          :pwd => 'pass',
-          :digestPassword => false
+      cmd_json=<<-EOS.gsub(/$\n/, '')
+      {
+          "updateUser": "new_user",
+          "pwd": "pass",
+          "digestPassword": false
       }
+      EOS
       provider.expects(:mongo_eval).
-        with("db.runCommand(#{cmd.to_json})", 'new_database')
+        with("db.runCommand(#{cmd_json})", 'new_database')
       provider.password_hash=("newpass")
     end
   end


### PR DESCRIPTION
while we create a db and a user, we define something like this:

```
  mongodb::db { 'testdb':
     user => 'testuser',
     password => 'testpass',
     require => Class['::mongodb::server'],
 }
```
or 
```
  mongodb::db { 'testdb':
     user => 'testuser',
     password_hash => '19c8747ac7b3654045c99bea032d61be',
     require => Class['::mongodb::server'],
 }
```

19c8747ac7b3654045c99bea032d61be is equal to md5('testuser:mongo:testpass').

what we expect here is that we can authenticate a user in a client like:

```python
db.authenticate('testuser', 'testpass')
``` 
or
```javascript
db.auth('testuser', 'testpass')
```

However, after I apply my puppet pp file the first time,  I can only use the password_hash to auth a user:
```
db.auth('testuser', '19c8747ac7b3654045c99bea032d61be')
```
The plaintext password 'testpass' doesn't work at all.
 
**Later,  I try to apply the same pp file again without modify anything. After that, something curious happened, puppet log notice me that the password_hash changed from 84b719f4c9000b640c3f1bfe3257341e to 19c8747ac7b3654045c99bea032d61be.**
(Here 84b719f4c9000b640c3f1bfe3257341e is equal to md5('testuser:mongo:19c8747ac7b3654045c99bea032d61be') )

So I try to read the source code of this module, I found that it create a new User with the follwoing command:

```javascript
db.createUser{"user":"testuser","pwd":"19c8747ac7b3654045c99bea032d61be", "customData":{"createdBy":"Puppet Mongodb_user['testuser'] Password[@resource[:password_hash]]"},"roles":["dbAdmin"]}
```

and update a User's password user the following code:
```javascript
db.runCommand{"updateUser":"testuser","pwd":"19c8747ac7b3654045c99bea032d61be", "digestPassword":false}
```

where the field `digestPassword = false` tell the mongodb server store the user-hashed password directly.

The mongo js client's createUser command doesn't support the filed , so I fix it by changing createUser to runCommand.

PS. The filed `passwordDigestor` doesn't work.

My system is Debian 7, and my mongo version is 2.6.0 
