### PR TITLE
Fix server acceptance tests

### DIFF
--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -11,6 +11,7 @@ class mongodb::server::service {
   $service_ensure = $ensure ? {
     absent  => false,
     purged  => false,
+    stopped => false,
     default => true
   }
 

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -35,7 +35,12 @@ describe 'mongodb::server class' do
           puts "XXX uninstalls mongodb because changing the port with tengen doesn't work because they have a crappy init script"
           pp = <<-EOS
             class {'mongodb::globals': manage_package_repo => #{tengen}, }
-            -> class { 'mongodb::server': ensure => absent, }
+            -> class { 'mongodb::server':
+                 ensure => absent,
+                 package_ensure => absent,
+                 service_ensure => stopped,
+                 service_enable => false
+               }
             -> class { 'mongodb::client': ensure => absent, }
           EOS
           apply_manifest(pp, :catch_failures => true)
@@ -98,7 +103,12 @@ describe 'mongodb::server class' do
       it 'uninstalls mongodb' do
         pp = <<-EOS
           class {'mongodb::globals': manage_package_repo => #{tengen}, }
-          -> class { 'mongodb::server': ensure => absent, }
+          -> class { 'mongodb::server':
+               ensure => absent,
+               package_ensure => absent,
+               service_ensure => stopped,
+               service_enable => false
+             }
           -> class { 'mongodb::client': ensure => absent, }
         EOS
         apply_manifest(pp, :catch_failures => true)


### PR DESCRIPTION
The mongodb::server::ensure parameter is no longer sufficient to
describe the state of the package, config files, and service. This was
causing the acceptance tests to fail when trying to uninstall mongodb
because the manifest was attempting to ensure the service was running
while the package was uninstalled. This design should be reworked, but
in the mean time this commit adds the parameters necessary to
successfully uninstall mongodb. It also adds "stopped" as a valid value
for service_ensure to correspond with the valid values for the package
parameter.