### PR TITLE
Add support for RHEL 7

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -57,7 +57,10 @@ class mongodb::params inherits mongodb::globals {
         $dbpath              = '/var/lib/mongodb'
         $logpath             = '/var/log/mongodb/mongodb.log'
         $bind_ip             = pick($::mongodb::globals::bind_ip, ['127.0.0.1'])
-        $pidfilepath         = '/var/run/mongodb/mongodb.pid'
+        $pidfilepath         = $::operatingsystemrelease ? {
+          /^7/    => '/var/run/mongodb/mongod.pid',
+          default => '/var/run/mongodb/mongodb.pid',
+        }
         $fork                = true
         $journal             = true
       }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -35,6 +35,9 @@ RSpec.configure do |c|
     when 'RedHat'
       on hosts, 'puppet module install stahnma-epel'
       apply_manifest_on hosts, 'include epel'
+      if fact('operatingsystemrelease') =~ /^7/
+        shell('yum install -y iptables-services')
+      end
       on hosts, 'service iptables stop'
     end
   end


### PR DESCRIPTION
EPEL 7 packages mongodb with a different pidfile path than prior
package versions. This commit updates the pidfile path in params.pp so
that the service can start if installed from epel. It also fixes the
spec helper so that iptables can be stopped on RHEL 7.