### PR TITLE
Fixed password rehash bug and added rhel_6 compatibility by supporting ruby 1.8.7 with ordered hashe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,4 +27,8 @@ else
   gem 'puppet', :require => false
 end
 
+if RUBY_VERSION < "1.9"
+  gem 'activesupport', '<=3.1.0', :require => false
+end
+
 # vim:ft=ruby

--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -1,13 +1,24 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mongodb'))
 Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::Mongodb) do
+  # In ruby 1.9+ Hashes are inherently ordered. In lesser versions of ruby
+  # we need to use an ordered_hash library to maintain the same behaviour.
+  # In mongo db.runCommand() must use an orderedHash *always* as the first
+  # JSON key must be the mongo db command.
+  if RUBY_VERSION < "1.9"
+    require 'active_support/ordered_hash'
+    class OrderedHash < ActiveSupport::OrderedHash
+    end
+  else
+    class OrderedHash < Hash
+    end
+  end
+  require 'json'
 
   desc "Manage users for a MongoDB database."
 
   defaultfor :kernel => 'Linux'
 
   def self.instances
-    require 'json'
-
     if mongo_24?
       dbs = JSON.parse mongo_eval('printjson(db.getMongo().getDBs()["databases"].map(function(db){return db["name"]}))') || 'admin'
 
@@ -53,8 +64,6 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
   mk_resource_methods
 
   def create
-
-
     if mongo_24?
       user = {
         :user => @resource[:username],
@@ -64,21 +73,21 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
 
       mongo_eval("db.addUser(#{user.to_json})", @resource[:database])
     else
-      user = {
-        :user => @resource[:username],
-        :pwd => @resource[:password_hash],
-        :customData => { :createdBy => "Puppet Mongodb_user['#{@resource[:name]}']" },
-        :roles => @resource[:roles]
-      }
+      cmd = OrderedHash.new
+      cmd[:createUser] = @resource[:username]
+      cmd[:pwd] = @resource[:password_hash]
+      cmd[:customData] = { :createdBy => "Puppet Mongodb_user['#{@resource[:name]}']" }
+      cmd[:roles] = @resource[:roles]
+      cmd[:digestPassword] = false
 
-      mongo_eval("db.createUser(#{user.to_json})", @resource[:database])
+      mongo_eval("db.runCommand(#{cmd.to_json})", @resource[:database])
     end
 
     @property_hash[:ensure] = :present
     @property_hash[:username] = @resource[:username]
     @property_hash[:database] = @resource[:database]
     @property_hash[:password_hash] = ''
-    @property_hash[:rolse] = @resource[:roles]
+    @property_hash[:roles] = @resource[:roles]
 
     exists? ? (return true) : (return false)
   end
@@ -97,11 +106,10 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
   end
 
   def password_hash=(value)
-    cmd = {
-        :updateUser => @resource[:username],
-        :pwd => @resource[:password_hash],
-        :digestPassword => false
-    }
+    cmd = OrderedHash.new
+    cmd[:updateUser] = @resource[:username]
+    cmd[:pwd] = @resource[:password_hash]
+    cmd["digestPassword"] = false
 
     mongo_eval("db.runCommand(#{cmd.to_json})", @resource[:database])
   end

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -1,6 +1,15 @@
 require 'spec_helper'
 require 'json'
 
+if RUBY_VERSION < "1.9"
+  require 'active_support/ordered_hash'
+  class OrderedHash < ActiveSupport::OrderedHash
+  end
+else
+  class OrderedHash < Hash
+  end
+end
+
 describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   let(:raw_users) do
@@ -39,15 +48,14 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'create' do
     it 'creates a user' do
-      user = {
-        :user => 'new_user',
-        :pwd => 'pass',
-        :customData => { :createdBy => "Puppet Mongodb_user['new_user']" },
-        :roles => ['role1','role2'],
-      }
+      cmd = OrderedHash.new
+      cmd[:createUser] = 'new_user'
+      cmd[:pwd] = 'pass'
+      cmd[:customData] = { :createdBy => "Puppet Mongodb_user['new_user']" }
+      cmd[:roles] = ['role1','role2']
+      cmd[:digestPassword] = false
 
-
-      provider.expects(:mongo_eval).with("db.createUser(#{user.to_json})", 'new_database')
+      provider.expects(:mongo_eval).with("db.runCommand(#{cmd.to_json})", 'new_database')
       provider.create
     end
   end
@@ -73,11 +81,10 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'password_hash=' do
     it 'changes a password_hash' do
-      cmd = {
-          :updateUser => 'new_user',
-          :pwd => 'pass',
-          :digestPassword => false
-      }
+      cmd = OrderedHash.new
+      cmd[:updateUser] = 'new_user'
+      cmd[:pwd] = 'pass'
+      cmd[:digestPassword] = false
       provider.expects(:mongo_eval).
         with("db.runCommand(#{cmd.to_json})", 'new_database')
       provider.password_hash=("newpass")


### PR DESCRIPTION
PR #150 fixes the password rehash issue for anyone using ruby 1.9+, but doesn't take in to account ruby's hash sorting in 1.8+ and below. This breaks RHEL 6 compatibility.

OrderedHash has been added to the module for both versions. This is required for db.runCommand() in mongo as the first key in the JSON output must be the mongo db command.