### PR TITLE
Password rehash fix for rhel_6/ruby 1.8.7 support (and 1.9.0+)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development, :unit_tests do
   gem 'simplecov',               :require => false
   gem 'puppet_facts',            :require => false
   gem 'json',                    :require => false
+  gem 'activesupport', '3.1.0',  :require => false if RUBY_VERSION < '1.9.0'
 end
 
 group :system_tests do

--- a/lib/puppet/feature/json.rb
+++ b/lib/puppet/feature/json.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:json, :libs => ["json"])

--- a/lib/puppet/feature/orderedhash.rb
+++ b/lib/puppet/feature/orderedhash.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:orderedhash, :libs => ["active_support/ordered_hash"])

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -57,6 +57,20 @@ class mongodb::server::config {
   if ($logpath and $syslog) { fail('You cannot use syslog with logpath')}
 
   if ($ensure == 'present' or $ensure == true) {
+    # Install external mongo provider dependencies for ruby < 1.9.0
+    if versioncmp($::rubyversion, '1.9.0') < 0 {
+      # Active support provides ordered hashes and Ruby 1.8.7 must use ver 3.1.0 
+      package { 'activesupport':
+        ensure    => '3.1.0',
+        provider  => 'gem',
+      }
+      package { 'json':
+        ensure    => 'installed',
+        provider  => 'gem',
+      }
+      Package['activesupport'] -> Package<| provider == 'mongodb' |>
+      Package['json'] -> Package<| provider == 'mongodb' |>
+    }
 
     # Exists for future compatibility and clarity.
     if $auth {

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -1,5 +1,8 @@
 require 'spec_helper'
 require 'json'
+if RUBY_VERSION < '1.9.0'
+  require 'active_support/ordered_hash'
+else
 
 describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
@@ -39,15 +42,18 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'create' do
     it 'creates a user' do
-      user = {
-        :user => 'new_user',
-        :pwd => 'pass',
-        :customData => { :createdBy => "Puppet Mongodb_user['new_user']" },
-        :roles => ['role1','role2'],
-      }
+      if RUBY_VERSION < '1.9.0'
+        cmd = ActiveSupport::OrderedHash.new
+      else
+        cmd = Hash.new
+      end
+      cmd[:user] = 'new_user'
+      cmd[:pwd] = 'pass'
+      cmd[:customData] = { :createdBy => "Puppet Mongodb_user['new_user']" }
+      cmd[:roles] = ['role1','role2']
+      cmd[:digestPassword] = false
 
-
-      provider.expects(:mongo_eval).with("db.createUser(#{user.to_json})", 'new_database')
+      provider.expects(:mongo_eval).with("db.runCommand(#{cmd.to_json})", 'new_database')
       provider.create
     end
   end
@@ -73,11 +79,14 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'password_hash=' do
     it 'changes a password_hash' do
-      cmd = {
-          :updateUser => 'new_user',
-          :pwd => 'pass',
-          :digestPassword => false
-      }
+      if RUBY_VERSION < '1.9.0'
+        cmd = ActiveSupport::OrderedHash.new
+      else
+        cmd = Hash.new
+      end
+      cmd[:updateUser] = 'new_user'
+      cmd[:pwd] = 'pass'
+      cmd[:digestPassword] = false
       provider.expects(:mongo_eval).
         with("db.runCommand(#{cmd.to_json})", 'new_database')
       provider.password_hash=("newpass")


### PR DESCRIPTION
This PR fixes the password_rehash issue referenced in puppetlabs#150

In addition, it ensures that this works on rhel_6/ruby 1.8.7 installations as well as newer ones. Since it depends on the
support of an external gems, it ensures that they are installed in an idempotent manner and that the providers become
suitable only after the requirements are installed (if necessary).