### PR TITLE
password rehash fix for rhel_6 or ruby 1.8.7 support (as well as other rubies)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ group :development, :unit_tests do
   gem 'simplecov',               :require => false
   gem 'puppet_facts',            :require => false
   gem 'json',                    :require => false
+  gem 'activesupport', '3.1.0',  :require => false if RUBY_VERSION < '1.9.0'
 end
 
 group :system_tests do

--- a/lib/puppet/feature/json.rb
+++ b/lib/puppet/feature/json.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:json, :libs => ["json"])

--- a/lib/puppet/feature/orderedhash.rb
+++ b/lib/puppet/feature/orderedhash.rb
@@ -1,0 +1,3 @@
+require 'puppet/util/feature'
+
+Puppet.features.add(:orderedhash, :libs => ["active_support/ordered_hash"])

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -57,6 +57,20 @@ class mongodb::server::config {
   if ($logpath and $syslog) { fail('You cannot use syslog with logpath')}
 
   if ($ensure == 'present' or $ensure == true) {
+    # Install external mongo provider dependencies for ruby < 1.9.0
+    if versioncmp($::rubyversion, '1.9.0') < 0 {
+      # Active support provides ordered hashes and Ruby 1.8.7 must use ver 3.1.0 
+      package { 'activesupport':
+        ensure    => '3.1.0',
+        provider  => 'gem',
+      }
+      package { 'json':
+        ensure    => 'installed',
+        provider  => 'gem',
+      }
+      Package['activesupport'] -> Package<| provider == 'mongodb' |>
+      Package['json'] -> Package<| provider == 'mongodb' |>
+    }
 
     # Exists for future compatibility and clarity.
     if $auth {


### PR DESCRIPTION
This PR fixes the password_rehash issue referenced in puppetlabs#150

In addition, it ensures that this works on rhel_6/ruby 1.8.7 installations as well as newer ones. Since it depends on the
support of an external gems, it ensures that they are installed in an idempotent manner and that the providers become
suitable only after the requirements are installed (if necessary).