### PR TITLE
Fix the bug mongo js client fail to run under non-default port

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -1,3 +1,4 @@
+require 'yaml'
 class Puppet::Provider::Mongodb < Puppet::Provider
 
   # Without initvars commands won't work.
@@ -22,8 +23,9 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     if mongorc_file
         cmd = mongorc_file + cmd
     end
-
-    out = mongo([db, '--quiet', '--eval', cmd])
+    config = YAML.load_file('/etc/mongod.conf')
+    port = config['net.port']
+    out = mongo([db, '--quiet', '--port', port, '--eval', cmd])
 
     out.gsub!(/ObjectId\(([^)]*)\)/, '\1')
     out


### PR DESCRIPTION
The mongo js client can only work under the default port, I try to solve it by  passing the port argument from the provider and find its very complex.

So I just simply read it from the config file and such solution works for my projects.

pls help review it.