### PR TITLE
Fix port in 2.6 mongo.conf template

### DIFF
--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -81,7 +81,7 @@ security.javascriptEnabled: <%= @noscripting %>
 <% if @bind_ip -%>
 net.bindIp:  <%= Array(@bind_ip).join(',') %>
 <% end -%>
-net.port: <%= @port %>
+net.port: <%= @port || 27017 %>
 <% if @objcheck -%>
 net.wireObjectCheck: <%= @objcheck %>
 <% end -%>


### PR DESCRIPTION
The changes in #151 introduced a new way of handling the user-specified
port that incidentally left the port value empty in the 2.6 config
file. The port is required to be defined in the config file in order
for the fix introduced in #165 to work. This change redefined the
default port in the template if it is not already defined by a manifest.