### PR TITLE
Fix some lint error to reach 5.0 on Code Quality

### DIFF
--- a/manifests/client/install.pp
+++ b/manifests/client/install.pp
@@ -20,9 +20,9 @@ class mongodb::client::install {
 
   if $package_name {
     package { 'mongodb_client':
-      ensure  => $my_package_ensure,
-      name    => $package_name,
-      tag     => 'mongodb',
+      ensure => $my_package_ensure,
+      name   => $package_name,
+      tag    => 'mongodb',
     }
   }
 }

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -19,9 +19,9 @@ define mongodb::db (
 ) {
 
   mongodb_database { $name:
-    ensure   => present,
-    tries    => $tries,
-    require  => Class['mongodb::server'],
+    ensure  => present,
+    tries   => $tries,
+    require => Class['mongodb::server'],
   }
 
   if $password_hash {

--- a/manifests/mongos/install.pp
+++ b/manifests/mongos/install.pp
@@ -24,8 +24,8 @@ class mongodb::mongos::install (
 
   if !defined(Package[$package_name]) {
     package { 'mongodb_mongos':
-      ensure  => $my_package_ensure,
-      name    => $package_name,
+      ensure => $my_package_ensure,
+      name   => $package_name,
     }
   }
 

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -27,8 +27,8 @@ class mongodb::server::install {
   }
 
   package { 'mongodb_server':
-    ensure  => $my_package_ensure,
-    name    => $package_name,
-    tag     => 'mongodb',
+    ensure => $my_package_ensure,
+    name   => $package_name,
+    tag    => 'mongodb',
   }
 }

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -39,7 +39,7 @@ class mongodb::server::service {
   }
 
   if $service_ensure {
-    mongodb_conn_validator { "mongodb":
+    mongodb_conn_validator { 'mongodb':
       server  => $bind_ip,
       port    => $port_real,
       timeout => '240',

--- a/tests/sharding.pp
+++ b/tests/sharding.pp
@@ -4,13 +4,13 @@ node 'mongos' {
     manage_package_repo => true,
   }->
   class {'::mongodb::server':
-    configsvr       => true,
-    bind_ip         => $::ipaddress,
+    configsvr => true,
+    bind_ip   => $::ipaddress,
   }->
   class {'::mongodb::client':
   }->
   class {'::mongodb::mongos':
-    configdb        => ["${::ipaddress}:27019"],
+    configdb => ["${::ipaddress}:27019"],
   }->
   mongodb_shard { 'rs1' :
     member => 'rs1/mongod1:27018',


### PR DESCRIPTION
Fixe the error reported on the forge that was causing a 4.8 grade and
not a 5.0. The error were :

* Double quoted string containing no variables - 1 occurrence.
* Indentation of => is not properly aligned - 11 occurrences