### PR TITLE
add arbiter configuration

### DIFF
--- a/lib/puppet/type/mongodb_replset.rb
+++ b/lib/puppet/type/mongodb_replset.rb
@@ -17,6 +17,10 @@ Puppet::Type.newtype(:mongodb_replset) do
     desc "The name of the replicaSet"
   end
 
+  newparam(:arbiter) do
+    desc "The replicaSet arbiter"
+  end
+
   newproperty(:members, :array_matching => :all) do
     desc "The replicaSet members"
 

--- a/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
@@ -31,6 +31,17 @@ describe Puppet::Type.type(:mongodb_replset).provider(:mongo) do
       provider.create
       provider.flush
     end
+
+    it 'should create a replicaset with arbiter' do
+      provider.class.stubs(:get_replset_properties)
+      provider.stubs(:alive_members).returns(valid_members)
+      provider.stubs(:rs_arbiter).returns('mongo3:27017')
+      provider.expects('rs_initiate').with("{ _id: \"rs_test\", members: [ { _id: 0, host: \"mongo1:27017\" },{ _id: 1, host: \"mongo2:27017\" },{ _id: 2, host: \"mongo3:27017\", arbiterOnly: \"true\" } ] }", "mongo1:27017").returns(
+        { "info" => "Config now saved locally.  Should come online in about a minute.",
+          "ok"   => 1 } )
+      provider.create
+      provider.flush
+    end
   end
 
   describe '#exists?' do

--- a/tests/replicaset.pp
+++ b/tests/replicaset.pp
@@ -8,6 +8,7 @@ node default {
     replset    => 'rsmain'
   }
   mongodb_replset{'rsmain':
-    members => ['mongo1:27017', 'mongo2:27017', 'mongo3:27017']
+    members => ['mongo1:27017', 'mongo2:27017', 'mongo3:27017' ],
+    arbiter => 'mongo3:27017',
   }
 }


### PR DESCRIPTION
This commit adds the ability to configure a mongodb member as an arbiter. The
feature is very simplistic and will check for each member if it's an arbiter.
If the arbiter is changed after provision, the configuration will not change.
This is both as a safe guard but would also add on complexity.

An example is provided in `tests/replicaset.pp`:

    mongodb_replset{'rsmain':
      members => ['mongo1:27017', 'mongo2:27017', 'mongo3:27017' ],
      arbiter => 'mongo3:27017',
    }

The above configuration will set `mongo3:27017` as an arbiter.

This has been tested to run in Vagrant with 3 nodes. It's built upon the
PR by @victorgp, so he deserves some recognition. However this works a
bit different.

Thanks!