### PR TITLE
Replsetfix

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -230,7 +230,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo) do
       # Add members to an existing replset
       if master = master_host(alive_hosts)
         current_hosts = db_ismaster(master)['hosts']
-        Puppet.debug "Current Hosts are: #{current_hosts}"
+        Puppet.debug "Current Hosts are: #{current_hosts.inspect}"
         newhosts = alive_hosts - current_hosts
         newhosts.each do |host|
           output = rs_add(host, master)

--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -177,10 +177,10 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo) do
           end
 
           # This node is alive and supposed to be a member of our set
-          Puppet.debug "Host #{self.name} is available for replset #{status['set']}"
+          Puppet.debug "Host #{host} is available for replset #{status['set']}"
           true
         elsif status.has_key?('info')
-          Puppet.debug "Host #{self.name} is alive but unconfigured: #{status['info']}"
+          Puppet.debug "Host #{host} is alive but unconfigured: #{status['info']}"
           true
         end
       rescue Puppet::ExecutionFailure
@@ -230,6 +230,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo) do
       # Add members to an existing replset
       if master = master_host(alive_hosts)
         current_hosts = db_ismaster(master)['hosts']
+        Puppet.debug "Current Hosts are: #{current_hosts}"
         newhosts = alive_hosts - current_hosts
         newhosts.each do |host|
           output = rs_add(host, master)

--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -119,13 +119,16 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo) do
         end
       end
     end
-
-    if hash['bind_ip'] and ! hash['bind_ip'].eql? '0.0.0.0'
-      ip_real = hash['bind_ip']
-    else
-      ip_real = '127.0.0.1'
+    
+    if hash['bind_ip']
+      ip_bind = hash['bind_ip'].split(',').first
+      if ip_bind.eql? '0.0.0.0'
+        ip_real = '127.0.0.1'
+      else
+        ip_real = ip_bind
+      end
     end
-
+ 
     if hash['port']
       port_real = hash['port']
     elsif !hash['port'] and hash['configsvr']


### PR DESCRIPTION
We had a problem where the mongodb_replset threw an error when bind_ip was set to multiple values.

We created our mongodb servers like this:
class {'::mongodb::server':
    ensure  => true,
    bind_ip => ['127.0.0.1',$::ipaddress_em1]
}

This caused problems during execution. My solution was to modify the code so that the first IP address in the bind_ip list is used.

I also had to change a few debug statements until I saw what was really going on...


