### PR TITLE
Various 26 fix

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -27,11 +27,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     file
   end
 
-  # Mongo Command Wrapper
-  def self.mongo_eval(cmd, db = 'admin')
-    if mongorc_file
-        cmd = mongorc_file + cmd
-    end
+  def self.get_conn_string
     file = get_mongod_conf_file
     # The mongo conf is probably a key-value store, even though 2.6 is
     # supposed to use YAML, because the config template is applied
@@ -40,17 +36,51 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     # config files.
     config = YAML.load_file(file)
     if config.kind_of?(Hash) # Using a valid YAML file for mongo 2.6
+      bindip = config['net.bindIp']
       port = config['net.port']
+      shardsvr = config['sharding.clusterRole']
+      confsvr = config['sharding.clusterRole']
     else # It has to be a key-value config file
       config = {}
       File.readlines(file).collect do |line|
          k,v = line.split('=')
          config[k.rstrip] = v.lstrip.chomp if k and v
       end
+      bindip = config['bind_ip']
       port = config['port']
+      shardsvr = config['shardsvr']
+      confsvr = config['confsvr']
     end
 
-    out = mongo([db, '--quiet', '--port', port, '--eval', cmd])
+    if bindip
+      first_ip_in_list = bindip.split(',').first
+      if first_ip_in_list.eql? '0.0.0.0'
+        ip_real = '127.0.0.1'
+      else
+        ip_real = first_ip_in_list
+      end
+    end
+
+    if port
+      port_real = port
+    elsif !port and (confsvr.eql? 'configsvr' or confsvr.eql? 'true')
+      port_real = 27019
+    elsif !port and (shardsvr.eql? 'shardsvr' or shardsvr.eql? 'true')
+      port_real = 27018
+    else
+      port_real = 27017
+    end
+
+    "#{ip_real}:#{port_real}"
+  end
+
+  # Mongo Command Wrapper
+  def self.mongo_eval(cmd, db = 'admin')
+    if mongorc_file
+        cmd = mongorc_file + cmd
+    end
+
+    out = mongo([db, '--quiet', '--host', get_conn_string, '--eval', cmd])
 
     out.gsub!(/ObjectId\(([^)]*)\)/, '\1')
     out

--- a/lib/puppet/provider/mongodb_shard/mongo.rb
+++ b/lib/puppet/provider/mongodb_shard/mongo.rb
@@ -1,4 +1,5 @@
-Puppet::Type.type(:mongodb_shard).provide(:mongo) do
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'mongodb'))
+Puppet::Type.type(:mongodb_shard).provide(:mongo, :parent => Puppet::Provider::Mongodb ) do
 
   desc "Manage mongodb sharding."
 

--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -2,7 +2,7 @@
 class mongodb::mongos (
   $ensure           = $mongodb::params::mongos_ensure,
   $config           = $mongodb::params::mongos_config,
-  $config_content   = $mongodb::params::mongos_config_content,
+  $config_content   = undef,
   $configdb         = $mongodb::params::mongos_configdb,
   $service_provider = $mongodb::params::mongos_service_provider,
   $service_name     = $mongodb::params::mongos_service_name,
@@ -11,6 +11,12 @@ class mongodb::mongos (
   $service_status   = $mongodb::params::mongos_service_status,
   $package_ensure   = $mongodb::params::package_ensure_mongos,
   $package_name     = $mongodb::params::mongos_package_name,
+  $unixsocketprefix = undef,
+  $pidfilepath      = undef,
+  $logpath          = undef,
+  $bind_ip          = undef,
+  $fork             = undef,
+  $port             = undef,
 ) inherits mongodb::params {
 
   if ($ensure == 'present' or $ensure == true) {

--- a/manifests/mongos/config.pp
+++ b/manifests/mongos/config.pp
@@ -12,7 +12,7 @@ class mongodb::mongos::config (
     if $config_content {
       $config_content_real = $config_content
     } else {
-      $config_content_real = template('mongodb/mongos.conf.erb')
+      $config_content_real = template('mongodb/mongodb-shard.conf.erb')
     }
 
     file { $config:

--- a/manifests/mongos/service.pp
+++ b/manifests/mongos/service.pp
@@ -5,6 +5,8 @@ class mongodb::mongos::service (
   $service_ensure   = $mongodb::mongos::service_ensure,
   $service_status   = $mongodb::mongos::service_status,
   $service_provider = $mongodb::mongos::service_provider,
+  $bind_ip          = $mongodb::mongos::bind_ip,
+  $port             = $mongodb::mongos::port,
 ) {
 
   $service_ensure_real = $service_ensure ? {
@@ -14,13 +16,19 @@ class mongodb::mongos::service (
     default => true
   }
 
+  if $port {
+    $port_real = $port
+  } else {
+    $port_real = '27017'
+  }
+
   if $::osfamily == 'RedHat' {
     file { '/etc/sysconfig/mongos' :
       ensure  => present,
       owner   => 'root',
       group   => 'root',
       mode    => '0755',
-      content => 'OPTIONS="--quiet -f /etc/mongos.conf"',
+      content => 'OPTIONS="--quiet -f /etc/mongodb-shard.conf"',
       before  => Service['mongos'],
     }
   }
@@ -41,6 +49,15 @@ class mongodb::mongos::service (
     provider  => $service_provider,
     hasstatus => true,
     status    => $service_status,
+  }
+
+  if $service_ensure {
+    mongodb_conn_validator { 'mongos':
+      server  => $bind_ip,
+      port    => $port_real,
+      timeout => '240',
+      require => Service['mongos'],
+    }
   }
 
 }

--- a/manifests/mongos/service.pp
+++ b/manifests/mongos/service.pp
@@ -22,6 +22,12 @@ class mongodb::mongos::service (
     $port_real = '27017'
   }
 
+  if $bind_ip == '0.0.0.0' {
+    $bind_ip_real = '127.0.0.1'
+  } else {
+    $bind_ip_real = $bind_ip
+  }
+
   if $::osfamily == 'RedHat' {
     file { '/etc/sysconfig/mongos' :
       ensure  => present,
@@ -51,9 +57,9 @@ class mongodb::mongos::service (
     status    => $service_status,
   }
 
-  if $service_ensure {
+  if $service_ensure_real {
     mongodb_conn_validator { 'mongos':
-      server  => $bind_ip,
+      server  => $bind_ip_real,
       port    => $port_real,
       timeout => '240',
       require => Service['mongos'],

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,6 +9,7 @@ class mongodb::params inherits mongodb::globals {
   $mongos_service_enable = pick($mongodb::globals::mongos_service_enable, true)
   $mongos_service_ensure = pick($mongodb::globals::mongos_service_ensure, 'running')
   $mongos_service_status = $mongodb::globals::mongos_service_status
+  $mongos_configdb       = '127.0.0.1:27019'
 
   # Amazon Linux's OS Family is 'Linux', operating system 'Amazon'.
   case $::osfamily {
@@ -45,7 +46,7 @@ class mongodb::params inherits mongodb::globals {
         $service_name        = pick($::mongodb::globals::service_name, 'mongod')
         $mongos_service_name = pick($::mongodb::globals::mongos_service_name, 'mongos')
         $config              = '/etc/mongod.conf'
-        $mongos_config       = '/etc/mongos.conf'
+        $mongos_config       = '/etc/mongodb-shard.conf'
         $dbpath              = '/var/lib/mongodb'
         $logpath             = '/var/log/mongodb/mongod.log'
         $pidfilepath         = '/var/run/mongodb/mongod.pid'
@@ -70,7 +71,7 @@ class mongodb::params inherits mongodb::globals {
         $mongos_package_name = pick($::mongodb::globals::mongos_package_name, 'mongodb-server')
         $service_name        = pick($::mongodb::globals::service_name, 'mongod')
         $config              = '/etc/mongodb.conf'
-        $mongos_config       = '/etc/mongos.conf'
+        $mongos_config       = '/etc/mongodb-shard.conf'
         $dbpath              = '/var/lib/mongodb'
         $logpath             = '/var/log/mongodb/mongodb.log'
         $bind_ip             = pick($::mongodb::globals::bind_ip, ['127.0.0.1'])
@@ -119,7 +120,7 @@ class mongodb::params inherits mongodb::globals {
           }
         }
         $mongos_service_name = pick($::mongodb::globals::mongos_service_name, 'mongos')
-        $mongos_config       = '/etc/mongos.conf'
+        $mongos_config       = '/etc/mongodb-shard.conf'
         $dbpath              = '/var/lib/mongodb'
         $logpath             = '/var/log/mongodb/mongodb.log'
         $bind_ip             = pick($::mongodb::globals::bind_ip, ['127.0.0.1'])
@@ -145,7 +146,7 @@ class mongodb::params inherits mongodb::globals {
         $service_name        = pick($::mongodb::globals::service_name, 'mongodb')
         $mongos_service_name = pick($::mongodb::globals::mongos_service_name, 'mongos')
         $config              = '/etc/mongodb.conf'
-        $mongos_config       = '/etc/mongos.conf'
+        $mongos_config       = '/etc/mongodb-shard.conf'
         $dbpath              = '/var/lib/mongodb'
         $logpath             = '/var/log/mongodb/mongodb.log'
         $bind_ip             = pick($::mongodb::globals::bind_ip, ['127.0.0.1'])

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -22,6 +22,12 @@ class mongodb::server::service {
     $port_real = $port
   }
 
+  if $bind_ip == '0.0.0.0' {
+    $bind_ip_real = '127.0.0.1'
+  } else {
+    $bind_ip_real = $bind_ip
+  }
+
   $service_ensure = $ensure ? {
     absent  => false,
     purged  => false,
@@ -40,7 +46,7 @@ class mongodb::server::service {
 
   if $service_ensure {
     mongodb_conn_validator { 'mongodb':
-      server  => $bind_ip,
+      server  => $bind_ip_real,
       port    => $port_real,
       timeout => '240',
       require => Service['mongodb'],

--- a/spec/acceptance/mongos_spec.rb
+++ b/spec/acceptance/mongos_spec.rb
@@ -9,7 +9,7 @@ describe 'mongodb::mongos class' do
       package_name = 'mongodb-server'
     end
     service_name = 'mongos'
-    config_file  = '/etc/mongos.conf'
+    config_file  = '/etc/mongodb-shard.conf'
 
     client_name  = 'mongo --version'
 
@@ -93,7 +93,7 @@ describe 'mongodb::mongos class' do
              }
           -> class { 'mongodb::client': ensure => absent, }
           -> class { 'mongodb::mongos':
-               ensure => absent,
+               ensure         => absent,
                package_ensure => absent,
                service_ensure => stopped,
                service_enable => false

--- a/spec/acceptance/mongos_spec.rb
+++ b/spec/acceptance/mongos_spec.rb
@@ -75,9 +75,7 @@ describe 'mongodb::mongos class' do
       end
 
       describe command(client_name) do
-        it do
-          should return_exit_status 0
-        end
+        its(:exit_status) { should eq 0 }
       end
     end
 

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -76,9 +76,7 @@ describe 'mongodb::server class' do
       end
 
       describe command(client_name) do
-        it do
-          should return_exit_status 0
-        end
+        its(:exit_status) { should eq 0 }
       end
     end
 

--- a/spec/classes/mongos_config_spec.rb
+++ b/spec/classes/mongos_config_spec.rb
@@ -12,12 +12,11 @@ describe 'mongodb::mongos::config' do
     end
 
     let :pre_condition do
-      "class { 'mongodb::mongos':
-       }"
+      "class { 'mongodb::mongos': }"
     end
 
     it {
-      should contain_file('/etc/mongos.conf')
+      should contain_file('/etc/mongodb-shard.conf')
     }
   end
 

--- a/spec/classes/mongos_install_spec.rb
+++ b/spec/classes/mongos_install_spec.rb
@@ -13,6 +13,7 @@ describe 'mongodb::mongos::install', :type => :class do
 
     let :pre_condition do
       "class { 'mongodb::mongos':
+         configdb     => ['127.0.0.1:27019'],
          package_name => 'mongo-foo',
        }"
     end

--- a/spec/classes/mongos_service_spec.rb
+++ b/spec/classes/mongos_service_spec.rb
@@ -12,6 +12,7 @@ describe 'mongodb::mongos::service', :type => :class do
 
     let :pre_condition do          
       "class { 'mongodb::mongos':
+         configdb => ['127.0.0.1:27019'],
        }"
     end 
 
@@ -34,6 +35,7 @@ describe 'mongodb::mongos::service', :type => :class do
 
     let :pre_condition do
       "class { 'mongodb::mongos':
+         configdb => ['127.0.0.1:27019'],
        }"
     end
 

--- a/spec/classes/mongos_spec.rb
+++ b/spec/classes/mongos_spec.rb
@@ -8,6 +8,12 @@ describe 'mongodb::mongos' do
     }
   end
 
+  let :params do
+    {
+      :configdb => ['127.0.0.1:27019']
+    }
+  end
+
   context 'with defaults' do
     it { should contain_class('mongodb::mongos::install') }
     it { should contain_class('mongodb::mongos::config') }

--- a/templates/mongodb-shard.conf.erb
+++ b/templates/mongodb-shard.conf.erb
@@ -1,0 +1,21 @@
+<% if @configdb -%>
+configdb = <%= Array(@configdb).join(',') %>
+<% end -%>
+<% if @bind_ip -%>
+bind_ip = <%= @bind_ip %>
+<% end -%>
+<% if @port -%>
+port = <%= @port %>
+<% end -%>
+<% if @fork -%>
+fork = <%= @fork %>
+<% end -%>
+<% if @pidfilepath -%>
+pidfilepath = <%= @pidfilepath %>
+<% end -%>
+<% if @logpath -%>
+logpath = <%= @logpath %>
+<% end -%>
+<% if @unixsocketprefix -%>
+unixSocketPrefix = <%= @unixsocketprefix %>
+<% end -%>

--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -81,7 +81,9 @@ security.javascriptEnabled: <%= @noscripting %>
 <% if @bind_ip -%>
 net.bindIp:  <%= Array(@bind_ip).join(',') %>
 <% end -%>
-net.port: <%= @port || 27017 %>
+<% if @port -%>
+net.port: <%= @port %>
+<% end -%>
 <% if @objcheck -%>
 net.wireObjectCheck: <%= @objcheck %>
 <% end -%>
@@ -101,6 +103,14 @@ replication.replSetName: <%= @replset %>
 <% end -%>
 <% if @oplog_size -%>
 replication.oplogSizeMB: <%= @oplog_size %>
+<% end -%>
+
+# Sharding
+<% if @configsvr -%>
+sharding.clusterRole: configsvr
+<% end -%>
+<% if @shardsvr -%>
+sharding.clusterRole: shardsvr
 <% end -%>
 
 #Operation Profiling

--- a/templates/mongos.conf.erb
+++ b/templates/mongos.conf.erb
@@ -1,3 +1,0 @@
-<% if @configdb -%>
-configdb = <%= Array(@configdb).join(',') %>
-<% end -%>

--- a/templates/mongos/Debian/mongos.erb
+++ b/templates/mongos/Debian/mongos.erb
@@ -54,7 +54,7 @@ NAME=mongos
 # Defaults.  Can be overridden by the /etc/default/$NAME
 # Other configuration options are located in $CONF file. See here for more:
 # http://dochub.mongodb.org/core/configurationoptions
-CONF=/etc/mongos.conf
+CONF=/etc/mongodb-shard.conf
 PIDFILE=/var/run/$NAME.pid
 ENABLE_MONGOD=yes
 

--- a/templates/mongos/RedHat/mongos.erb
+++ b/templates/mongos/RedHat/mongos.erb
@@ -5,12 +5,12 @@
 # chkconfig: 35 85 15
 # description: Mongo Router Process for sharding
 # processname: mongos
-# config: /etc/mongos.conf
-# pidfile: /var/run/mongos.pid
+# config: /etc/mongodb-shard.conf
+# pidfile: /var/run/mongodb/mongos.pid
 
 . /etc/rc.d/init.d/functions
 
-# mongos will read mongos.conf for configuration settings
+# mongos will read mongodb-shard.conf for configuration settings
 
 # Add variable to support multiple instances of mongos
 # The instance name is by default the name of this init script
@@ -25,9 +25,9 @@ INSTANCE=`basename $0`
 
 # By default OPTIONS just points to the /etc/mongod.conf config file
 # This can be overriden in /etc/sysconfig/mongod
-OPTIONS=" -f /etc/${INSTANCE}.conf"
+OPTIONS=" -f /etc/mongodb-shard.conf"
 
-PID_PATH=/var/run/
+PID_PATH=/var/run/mongodb
 PID_FILE=${PID_PATH}/${INSTANCE}.pid
 MONGO_BIN=/usr/bin/mongos
 MONGO_USER=<%=@user%>
@@ -52,10 +52,10 @@ start()
   echo -n $"Starting ${INSTANCE}: "
   ulimit -n $MONGO_ULIMIT
   touch ${PID_FILE}
-  touch '/var/log/mongodb/mongos.log'
+  touch '/var/log/mongodb/mongodb-shard.log'
   chown "${MONGO_USER}:${MONGO_GROUP}" "${PID_FILE}"
-  chown "${MONGO_USER}:${MONGO_GROUP}" '/var/log/mongodb/mongos.log'
-  daemon --user "$MONGO_USER" --pidfile $PID_FILE "$MONGO_BIN $OPTIONS --pidfilepath=$PID_FILE >>/var/log/mongodb/mongos.log 2>&1 &"
+  chown "${MONGO_USER}:${MONGO_GROUP}" '/var/log/mongodb/mongodb-shard.log'
+  daemon --user "$MONGO_USER" --pidfile $PID_FILE "$MONGO_BIN $OPTIONS --pidfilepath=$PID_FILE >>/var/log/mongodb/mongodb-shard.log 2>&1 &"
   RETVAL=$?
   echo
   [ $RETVAL -eq 0 ] && touch $MONGO_LOCK_FILE


### PR DESCRIPTION
This pull request aims to fix some differences in the behavior of the module depending on the mongodb version installed.

It : 

 * Ensure `rs.conf()` is run on the proper connection string (compatbile 2.4 and 2.6 conf format)
 * Ensure `shardsvr` and `confsvr` can be set in both versions (compatbile 2.4 and 2.6 conf format)
 * Make the sharding configuration be the same in 2.4 and 2.6 (using the 'official' way, ie. mongodb-shard.conf)
 * Make the mongo client connect to the proper `bind_ip` and `port` configuration