### PR TITLE
Add $restart param to control service restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,10 +430,12 @@ Default: <>
 #####`ssl_ca`
 Default: <>
 
-
 #####`service_manage`
 Whether or not the MongoDB service resource should be part of the catalog.
 Default: true
+
+#####`restart`
+Specifies whether the service should be restarted on config changes. Default: 'true'
 
 ####Class: mongodb::mongos
 class. This class should only be used if you want to implement sharding within
@@ -485,6 +487,9 @@ This setting can be used to specify if puppet should install the package or not
 #####`package_name`
 This setting can be used to specify the name of the package that should be installed.
 If not specified, the module will use whatever service name is the default for your OS distro.
+
+#####`restart`
+Specifies whether the service should be restarted on config changes. Default: 'true'
 
 ### Definitions
 

--- a/manifests/mongos/config.pp
+++ b/manifests/mongos/config.pp
@@ -20,7 +20,6 @@ class mongodb::mongos::config (
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
-      notify  => Class['mongodb::mongos::service']
     }
 
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,12 +7,14 @@ class mongodb::params inherits mongodb::globals {
   $service_enable        = pick($mongodb::globals::service_enable, true)
   $service_ensure        = pick($mongodb::globals::service_ensure, 'running')
   $service_status        = $mongodb::globals::service_status
+  $restart               = true
 
   $mongos_service_manage = pick($mongodb::globals::mongos_service_manage, true)
   $mongos_service_enable = pick($mongodb::globals::mongos_service_enable, true)
   $mongos_service_ensure = pick($mongodb::globals::mongos_service_ensure, 'running')
   $mongos_service_status = $mongodb::globals::mongos_service_status
   $mongos_configdb       = '127.0.0.1:27019'
+  $mongos_restart        = true
 
   # Amazon Linux's OS Family is 'Linux', operating system 'Amazon'.
   case $::osfamily {

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -97,7 +97,6 @@ class mongodb::server::config {
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
-      notify  => Class['mongodb::server::service']
     }
 
     file { $dbpath:


### PR DESCRIPTION
This PR is to add `restart` parameters for mongo & mongos which when set to:
- `false` - don't restart the service on config file changes
- `true` - (default) trigger service restarts on config file changes