### PR TITLE
Add support for ipv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,10 @@ This setting can be used to override the default MongoDB user group to be used
 for related files in the file system. If not specified, the module will use
 the default for your OS distro.
 
+#####`ipv6`
+This setting is used to configure MongoDB to turn on ipv6 support. If not specified
+and ipv6 address is passed to MongoDB bind_ip it will just fail.
+
 #####`bind_ip`
 This setting can be used to configure MonogDB process to bind to and listen
 for connections from applications on this address. If not specified, the
@@ -216,6 +220,10 @@ If not specified, the module will use the default for your OS distro.
 Specify the path to a file name for the log file that will hold all diagnostic
 logging information. Unless specified, mongod will output all log information
 to the standard output.
+
+#####`ipv6`
+This setting has to be true to configure MongoDB to turn on ipv6 support. If not specified
+and ipv6 address is passed to MongoDB bind_ip it will just fail.
 
 #####`bind_ip`
 Set this option to configure the mongod or mongos process to bind to and listen

--- a/lib/puppet/util/mongodb_validator.rb
+++ b/lib/puppet/util/mongodb_validator.rb
@@ -1,6 +1,6 @@
 require 'socket'
 require 'timeout'
-
+require 'ipaddr'
 
 module Puppet
   module Util
@@ -9,7 +9,7 @@ module Puppet
       attr_reader :mongodb_port
 
       def initialize(mongodb_server, mongodb_port)
-        @mongodb_server = mongodb_server
+        @mongodb_server = IPAddr.new(mongodb_server).to_s
         @mongodb_port   = mongodb_port
       end
 

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -15,6 +15,7 @@ class mongodb::globals (
 
   $user                 = undef,
   $group                = undef,
+  $ipv6                 = undef,
   $bind_ip              = undef,
 
   $version              = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,6 +80,7 @@ class mongodb (
   $slowms          = undef,
   $keyfile         = undef,
   $key             = undef,
+  $ipv6            = undef,
   $bind_ip         = undef,
   $pidfilepath     = undef
 ) inherits mongodb::params {
@@ -137,6 +138,7 @@ class mongodb (
     slowms          => $slowms,
     keyfile         => $keyfile,
     key             => $key,
+    ipv6            => $ipv6,
     bind_ip         => $bind_ip,
     pidfilepath     => $pidfilepath,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -2,6 +2,7 @@
 class mongodb::params inherits mongodb::globals {
   $ensure                = true
   $mongos_ensure         = true
+  $ipv6                  = undef
   $service_enable        = pick($mongodb::globals::service_enable, true)
   $service_ensure        = pick($mongodb::globals::service_ensure, 'running')
   $service_status        = $mongodb::globals::service_status

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -20,6 +20,7 @@ class mongodb::server (
 
   $logpath         = $mongodb::params::logpath,
   $bind_ip         = $mongodb::params::bind_ip,
+  $ipv6            = undef,
   $logappend       = true,
   $fork            = $mongodb::params::fork,
   $port            = undef,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -46,6 +46,7 @@ class mongodb::server::config {
   $slowms          = $mongodb::server::slowms
   $keyfile         = $mongodb::server::keyfile
   $key             = $mongodb::server::key
+  $ipv6            = $mongodb::server::ipv6
   $bind_ip         = $mongodb::server::bind_ip
   $directoryperdb  = $mongodb::server::directoryperdb
   $profile         = $mongodb::server::profile

--- a/spec/classes/server_config_spec.rb
+++ b/spec/classes/server_config_spec.rb
@@ -39,6 +39,15 @@ describe 'mongodb::server::config', :type => :class do
 
   end
 
+  describe 'with specific bind_ip values and ipv6' do
+    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $bind_ip = ['127.0.0.1', 'fd00:beef:dead:55::143'] $ipv6 = true }", "include mongodb::server"]}
+
+    it {
+      should contain_file('/etc/mongod.conf').with_content(/bind_ip\s=\s127\.0\.0\.1\,fd00:beef:dead:55::143/)
+      should contain_file('/etc/mongod.conf').with_content(/ipv6=true/)
+    }
+  end
+
   describe 'with specific bind_ip values' do
     let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $bind_ip = ['127.0.0.1', '10.1.1.13']}", "include mongodb::server"]}
 

--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -78,6 +78,9 @@ security.javascriptEnabled: <%= @noscripting %>
 
 
 # Net
+<% if @ipv6 -%>
+net.ipv6=<%= @ipv6 %>
+<% end -%>
 <% if @bind_ip -%>
 net.bindIp:  <%= Array(@bind_ip).join(',') %>
 <% end -%>

--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -8,6 +8,9 @@ logpath=<%= @logpath %>
 logappend=<%= @logappend %>
 <% end -%>
 <% end -%>
+<% if @ipv6 -%>
+ipv6=<%= @ipv6 %>
+<% end -%>
 <% if @bind_ip -%>
 # Set this option to configure the mongod or mongos process to bind to and
 # listen for connections from applications on this address.


### PR DESCRIPTION
Mongodb needs ipv6 config option set to true to bind to ipv6 address.
Also IP address needs to be validated before passing it to TCPSocket.

Closes-Bug: rhbz#1185652