### PR TITLE
Fix Debian mongos_* parameters scope.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -136,10 +136,6 @@ class mongodb::params inherits mongodb::globals {
         $dbpath                  = '/var/lib/mongodb'
         $logpath                 = '/var/log/mongodb/mongodb.log'
         $bind_ip                 = pick($::mongodb::globals::bind_ip, ['127.0.0.1'])
-        $mongos_pidfilepath      = undef
-        $mongos_unixsocketprefix = undef
-        $mongos_logpath          = undef
-        $mongos_fork             = undef
       } else {
         # although we are living in a free world,
         # I would not recommend to use the prepacked


### PR DESCRIPTION
Currently there is an issue with the scope of the variable that makes
possible for an assignement to be called twice. We now assign the
variable is the outer most scope.

Fix: https://github.com/puppetlabs/puppetlabs-mongodb/commit/d6f2c0266045d7a2c29b4fd65cd5d2a9438ef320#diff-2f383a197b1a428561b364755701d60eR139