### PR TITLE
Fix replset not working on mongo 3.x

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -252,6 +252,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, :parent => Puppet::Provider:
     # Dirty hack to remove JavaScript objects
     output.gsub!(/ISODate\((.+?)\)/, '\1 ')
     output.gsub!(/Timestamp\((.+?)\)/, '[\1]')
+    output.gsub!(/ObjectId\(([^)]*)\)/, '\1')
 
     #Hack to avoid non-json empty sets
     output = "{}" if output == "null\n"


### PR DESCRIPTION
Fix replset not working on mongo 3.x due to the output containing an ObjectID