### PR TITLE
prealloc setting needs to be negated

### DIFF
--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -44,7 +44,7 @@ storage.journal.enabled: false
 storage.journal.enabled: true
 <% end -%>
 <% if @noprealloc -%>
-storage.preallocDataFiles: <%= @noprealloc %>
+storage.preallocDataFiles: <%= !@noprealloc %>
 <% end -%>
 <% if @nssize -%>
 storage.nsSize: <%= @nssize %>


### PR DESCRIPTION
Prior to 2.6 the config option is `noprealloc: true`, now it's `storage.preallocDataFiles: false`, so the option `noprealloc` needs to be negated when using the 2.6 config template.