### PR TITLE
changed apt key to 40 chars to remove apt module warning

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -10,7 +10,7 @@ class mongodb::repo::apt inherits mongodb::repo {
       location    => $::mongodb::repo::location,
       release     => 'dist',
       repos       => '10gen',
-      key         => '9ECBEC467F0CEB10',
+      key         => '492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10',
       key_server  => 'hkp://keyserver.ubuntu.com:80',
       include_src => false,
     }


### PR DESCRIPTION
APT module give this warning 

    The id should be a full fingerprint (40 characters), see README.