### PR TITLE
spec: updates for rspec-puppet 2.x and rspec 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
 group :development, :unit_tests do
-  gem 'rspec-core', '3.1.7',     :require => false
   gem 'puppetlabs_spec_helper',  :require => false
+  gem 'rspec-puppet', '~> 2.0.0', :require => false
+
   gem 'simplecov',               :require => false
   gem 'puppet_facts',            :require => false
   gem 'json',                    :require => false

--- a/spec/acceptance/mongos_spec.rb
+++ b/spec/acceptance/mongos_spec.rb
@@ -54,28 +54,31 @@ describe 'mongodb::mongos class' do
       end
 
       describe package(package_name) do
-        it { should be_installed }
+        it { is_expected.to be_installed }
       end
 
       describe file(config_file) do
-        it { should be_file }
+        it { is_expected.to be_file }
       end
 
       describe service(service_name) do
-         it { should be_enabled }
-         it { should be_running }
+         it { is_expected.to be_enabled }
+         it { is_expected.to be_running }
       end
 
       describe port(27017) do
-        it { should be_listening }
+        it { is_expected.to be_listening }
       end
 
       describe port(27019) do
-        it { should be_listening }
+        it { is_expected.to be_listening }
       end
 
       describe command(client_name) do
-        its(:exit_status) { should eq 0 }
+        describe '#exit_status' do
+          subject { super().exit_status }
+          it { is_expected.to eq 0 }
+        end
       end
     end
 

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -59,24 +59,27 @@ describe 'mongodb::server class' do
       end
 
       describe package(package_name) do
-        it { should be_installed }
+        it { is_expected.to be_installed }
       end
 
       describe file(config_file) do
-        it { should be_file }
+        it { is_expected.to be_file }
       end
 
       describe service(service_name) do
-         it { should be_enabled }
-         it { should be_running }
+         it { is_expected.to be_enabled }
+         it { is_expected.to be_running }
       end
 
       describe port(27017) do
-        it { should be_listening }
+        it { is_expected.to be_listening }
       end
 
       describe command(client_name) do
-        its(:exit_status) { should eq 0 }
+        describe '#exit_status' do
+          subject { super().exit_status }
+          it { is_expected.to eq 0 }
+        end
       end
     end
 
@@ -93,7 +96,7 @@ describe 'mongodb::server class' do
       end
 
       describe port(27018) do
-        it { should be_listening }
+        it { is_expected.to be_listening }
       end
     end
 

--- a/spec/classes/client_install_spec.rb
+++ b/spec/classes/client_install_spec.rb
@@ -4,7 +4,7 @@ describe 'mongodb::client::install', :type => :class do
   describe 'it should create package' do
     let(:pre_condition) { ["class mongodb::client { $ensure = true $package_name = 'mongodb' }", "include mongodb::client"]}
     it {
-      should contain_package('mongodb_client').with({
+      is_expected.to contain_package('mongodb_client').with({
         :ensure => 'present',
         :name   => 'mongodb',
       })

--- a/spec/classes/mongos_config_spec.rb
+++ b/spec/classes/mongos_config_spec.rb
@@ -16,7 +16,7 @@ describe 'mongodb::mongos::config' do
     end
 
     it {
-      should contain_file('/etc/mongodb-shard.conf')
+      is_expected.to contain_file('/etc/mongodb-shard.conf')
     }
   end
 

--- a/spec/classes/mongos_install_spec.rb
+++ b/spec/classes/mongos_install_spec.rb
@@ -19,7 +19,7 @@ describe 'mongodb::mongos::install', :type => :class do
     end
 
     it {
-      should contain_package('mongodb_mongos').with({
+      is_expected.to contain_package('mongodb_mongos').with({
         :ensure => 'present',
         :name   => 'mongo-foo',
       })

--- a/spec/classes/mongos_service_spec.rb
+++ b/spec/classes/mongos_service_spec.rb
@@ -17,11 +17,11 @@ describe 'mongodb::mongos::service', :type => :class do
     end 
 
     describe 'include init script' do
-      it { should contain_file('/etc/init.d/mongos') }
+      it { is_expected.to contain_file('/etc/init.d/mongos') }
     end
 
     describe 'configure the mongos service' do
-      it { should contain_service('mongos') }
+      it { is_expected.to contain_service('mongos') }
     end
   end
 
@@ -40,15 +40,15 @@ describe 'mongodb::mongos::service', :type => :class do
     end
 
     describe 'include mongos sysconfig file' do
-      it { should contain_file('/etc/sysconfig/mongos') }
+      it { is_expected.to contain_file('/etc/sysconfig/mongos') }
     end
 
     describe 'include init script' do
-      it { should contain_file('/etc/init.d/mongos') }
+      it { is_expected.to contain_file('/etc/init.d/mongos') }
     end
 
     describe 'configure the mongos service' do
-      it { should contain_service('mongos') }
+      it { is_expected.to contain_service('mongos') }
     end
   end
 

--- a/spec/classes/mongos_spec.rb
+++ b/spec/classes/mongos_spec.rb
@@ -15,16 +15,16 @@ describe 'mongodb::mongos' do
   end
 
   context 'with defaults' do
-    it { should contain_class('mongodb::mongos::install') }
-    it { should contain_class('mongodb::mongos::config') }
-    it { should contain_class('mongodb::mongos::service') }
+    it { is_expected.to contain_class('mongodb::mongos::install') }
+    it { is_expected.to contain_class('mongodb::mongos::config') }
+    it { is_expected.to contain_class('mongodb::mongos::service') }
   end
 
   context 'when deploying on Solaris' do
     let :facts do
       { :osfamily        => 'Solaris' }
     end
-    it { expect { should raise_error(Puppet::Error) } }
+    it { expect { is_expected.to raise_error(Puppet::Error) } }
   end
 
 end

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -12,7 +12,7 @@ describe 'mongodb::repo', :type => :class do
     end
 
     it {
-      should contain_class('mongodb::repo::apt')
+      is_expected.to contain_class('mongodb::repo::apt')
     }
   end
 
@@ -25,7 +25,7 @@ describe 'mongodb::repo', :type => :class do
     end
 
     it {
-      should contain_class('mongodb::repo::yum')
+      is_expected.to contain_class('mongodb::repo::yum')
     }
   end
 

--- a/spec/classes/server_config_spec.rb
+++ b/spec/classes/server_config_spec.rb
@@ -6,7 +6,7 @@ describe 'mongodb::server::config', :type => :class do
     let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' }", "include mongodb::server"]}
 
     it {
-      should contain_file('/etc/mongod.conf')
+      is_expected.to contain_file('/etc/mongod.conf')
     }
 
   end
@@ -15,18 +15,18 @@ describe 'mongodb::server::config', :type => :class do
     let(:pre_condition) {[ "class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $user = 'mongod' $group = 'mongod' $port = 29017 $bind_ip = ['0.0.0.0'] $fork = true $logpath ='/var/log/mongo/mongod.log' $logappend = true }",  "include mongodb::server" ]}
 
     it {
-      should contain_file('/etc/mongod.conf').with({
+      is_expected.to contain_file('/etc/mongod.conf').with({
         :mode   => '0644',
         :owner  => 'root',
         :group  => 'root'
       })
 
-      should contain_file('/etc/mongod.conf').with_content(/^dbpath=\/var\/lib\/mongo/)
-      should contain_file('/etc/mongod.conf').with_content(/bind_ip\s=\s0\.0\.0\.0/)
-      should contain_file('/etc/mongod.conf').with_content(/^port = 29017$/)
-      should contain_file('/etc/mongod.conf').with_content(/^logappend=true/)
-      should contain_file('/etc/mongod.conf').with_content(/^logpath=\/var\/log\/mongo\/mongod\.log/)
-      should contain_file('/etc/mongod.conf').with_content(/^fork=true/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/^dbpath=\/var\/lib\/mongo/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/bind_ip\s=\s0\.0\.0\.0/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/^port = 29017$/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/^logappend=true/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/^logpath=\/var\/log\/mongo\/mongod\.log/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/^fork=true/)
     }
   end
 
@@ -34,7 +34,7 @@ describe 'mongodb::server::config', :type => :class do
     let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = absent }", "include mongodb::server"]}
 
     it {
-      should contain_file('/etc/mongod.conf').with({ :ensure => 'absent' })
+      is_expected.to contain_file('/etc/mongod.conf').with({ :ensure => 'absent' })
     }
 
   end
@@ -43,8 +43,8 @@ describe 'mongodb::server::config', :type => :class do
     let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $bind_ip = ['127.0.0.1', 'fd00:beef:dead:55::143'] $ipv6 = true }", "include mongodb::server"]}
 
     it {
-      should contain_file('/etc/mongod.conf').with_content(/bind_ip\s=\s127\.0\.0\.1\,fd00:beef:dead:55::143/)
-      should contain_file('/etc/mongod.conf').with_content(/ipv6=true/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/bind_ip\s=\s127\.0\.0\.1\,fd00:beef:dead:55::143/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/ipv6=true/)
     }
   end
 
@@ -52,7 +52,7 @@ describe 'mongodb::server::config', :type => :class do
     let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $bind_ip = ['127.0.0.1', '10.1.1.13']}", "include mongodb::server"]}
 
     it {
-      should contain_file('/etc/mongod.conf').with_content(/bind_ip\s=\s127\.0\.0\.1\,10\.1\.1\.13/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/bind_ip\s=\s127\.0\.0\.1\,10\.1\.1\.13/)
     }
   end
 
@@ -60,7 +60,7 @@ describe 'mongodb::server::config', :type => :class do
     let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $auth = true $dbpath = '/var/lib/mongo' $ensure = present }", "include mongodb::server"]}
 
     it {
-      should contain_file('/etc/mongod.conf').with_content(/^auth=true/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/^auth=true/)
     }
   end
   
@@ -68,7 +68,7 @@ describe 'mongodb::server::config', :type => :class do
     let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $set_parameter = 'textSearchEnable=true' $dbpath = '/var/lib/mongo' $ensure = present }", "include mongodb::server"]}
 
     it {
-      should contain_file('/etc/mongod.conf').with_content(/^setParameter = textSearchEnable=true/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/^setParameter = textSearchEnable=true/)
     }
   end
 
@@ -78,7 +78,7 @@ describe 'mongodb::server::config', :type => :class do
       let (:facts) { { :architecture => 'i686' } }
 
       it {
-        should contain_file('/etc/mongod.conf').with_content(/^journal = true/)
+        is_expected.to contain_file('/etc/mongod.conf').with_content(/^journal = true/)
       }
     end
   end
@@ -89,7 +89,7 @@ describe 'mongodb::server::config', :type => :class do
     context 'true and without quotafiles' do
       let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $quota = true }", "include mongodb::server"]}
       it {
-        should contain_file('/etc/mongod.conf').with_content(/^quota = true/)
+        is_expected.to contain_file('/etc/mongod.conf').with_content(/^quota = true/)
       }
     end
 
@@ -97,8 +97,8 @@ describe 'mongodb::server::config', :type => :class do
       let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $quota = true $quotafiles = 1 }", "include mongodb::server"]}
 
       it {
-        should contain_file('/etc/mongod.conf').with_content(/quota = true/)
-        should contain_file('/etc/mongod.conf').with_content(/quotaFiles = 1/)
+        is_expected.to contain_file('/etc/mongod.conf').with_content(/quota = true/)
+        is_expected.to contain_file('/etc/mongod.conf').with_content(/quotaFiles = 1/)
       }
     end
   end
@@ -108,7 +108,7 @@ describe 'mongodb::server::config', :type => :class do
       let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $syslog = true }", "include mongodb::server"]}
 
       it {
-        should contain_file('/etc/mongod.conf').with_content(/^syslog = true/)
+        is_expected.to contain_file('/etc/mongod.conf').with_content(/^syslog = true/)
       }
     end
 
@@ -116,7 +116,7 @@ describe 'mongodb::server::config', :type => :class do
       let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $syslog = true $logpath ='/var/log/mongo/mongod.log' }", "include mongodb::server"]}
 
       it {
-        expect { should contain_file('/etc/mongod.conf') }.to raise_error(Puppet::Error, /You cannot use syslog with logpath/)
+        expect { is_expected.to contain_file('/etc/mongod.conf') }.to raise_error(Puppet::Error, /You cannot use syslog with logpath/)
       }
     end
 

--- a/spec/classes/server_install_spec.rb
+++ b/spec/classes/server_install_spec.rb
@@ -6,7 +6,7 @@ describe 'mongodb::server::install', :type => :class do
     let(:pre_condition) { ["class mongodb::server { $package_ensure = true $dbpath = '/var/lib/mongo' $user = 'mongodb' $package_name = 'mongodb-server' }", "include mongodb::server"]}
 
     it {
-      should contain_package('mongodb_server').with({
+      is_expected.to contain_package('mongodb_server').with({
         :ensure => 'present',
         :name   => 'mongodb-server',
       })

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -9,15 +9,15 @@ describe 'mongodb::server' do
   end
 
   context 'with defaults' do
-    it { should contain_class('mongodb::server::install') }
-    it { should contain_class('mongodb::server::config') }
+    it { is_expected.to contain_class('mongodb::server::install') }
+    it { is_expected.to contain_class('mongodb::server::config') }
   end
 
   context 'when deploying on Solaris' do
     let :facts do
       { :osfamily        => 'Solaris' }
     end
-    it { expect { should raise_error(Puppet::Error) } }
+    it { expect { is_expected.to raise_error(Puppet::Error) } }
   end
 
 end

--- a/spec/defines/db_spec.rb
+++ b/spec/defines/db_spec.rb
@@ -10,12 +10,12 @@ describe 'mongodb::db', :type => :define do
   }
 
   it 'should contain mongodb_database with mongodb::server requirement' do
-    should contain_mongodb_database('testdb')\
+    is_expected.to contain_mongodb_database('testdb')\
       .with_require('Class[Mongodb::Server]')
   end
 
   it 'should contain mongodb_user with mongodb_database requirement' do
-    should contain_mongodb_user('User testuser on db testdb').with({
+    is_expected.to contain_mongodb_user('User testuser on db testdb').with({
       'username' => 'testuser',
       'database' => 'testdb',
       'require'  => 'Mongodb_database[testdb]',
@@ -24,18 +24,18 @@ describe 'mongodb::db', :type => :define do
 
   it 'should contain mongodb_user with proper roles' do
     params.merge!({'roles' => ['testrole1', 'testrole2']})
-    should contain_mongodb_user('User testuser on db testdb')\
+    is_expected.to contain_mongodb_user('User testuser on db testdb')\
       .with_roles(["testrole1", "testrole2"])
   end
 
   it 'should prefer password_hash instead of password' do
     params.merge!({'password_hash' => 'securehash'})
-    should contain_mongodb_user('User testuser on db testdb')\
+    is_expected.to contain_mongodb_user('User testuser on db testdb')\
       .with_password_hash('securehash')
   end
 
   it 'should contain mongodb_database with proper tries param' do
     params.merge!({'tries' => 5})
-    should contain_mongodb_database('testdb').with_tries(5)
+    is_expected.to contain_mongodb_database('testdb').with_tries(5)
   end
 end

--- a/spec/unit/mongodb_password_spec.rb
+++ b/spec/unit/mongodb_password_spec.rb
@@ -8,20 +8,20 @@ describe 'the mongodb_password function' do
   let(:scope) { PuppetlabsSpec::PuppetInternals.scope }
 
   it 'should exist' do
-    Puppet::Parser::Functions.function('mongodb_password').should == 'function_mongodb_password'
+    expect(Puppet::Parser::Functions.function('mongodb_password')).to eq('function_mongodb_password')
   end
 
   it 'should raise a ParseError if there no arguments' do
-    lambda { scope.function_mongodb_password([]) }.should( raise_error(Puppet::ParseError))
+    expect { scope.function_mongodb_password([]) }.to( raise_error(Puppet::ParseError))
   end
 
   it 'should raise a ParseError if there is more than 2 arguments' do
-    lambda { scope.function_mongodb_password(%w(foo bar baz)) }.should( raise_error(Puppet::ParseError))
+    expect { scope.function_mongodb_password(%w(foo bar baz)) }.to( raise_error(Puppet::ParseError))
   end
 
   it 'should convert password into a hash' do
     result = scope.function_mongodb_password(%w(user pass))
-    result.should(eq('e0c4a7b97d4db31f5014e9694e567d6b'))
+    expect(result).to(eq('e0c4a7b97d4db31f5014e9694e567d6b'))
   end
 
 end

--- a/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
@@ -63,7 +63,7 @@ describe Puppet::Type.type(:mongodb_replset).provider(:mongo) do
 }
 EOT
         provider.class.prefetch(resources)
-        resource.provider.exists?.should eql false
+        expect(resource.provider.exists?).to eql false
       end
     end
 
@@ -77,7 +77,7 @@ EOT
 }
 EOT
         provider.class.prefetch(resources)
-        resource.provider.exists?.should eql true
+        expect(resource.provider.exists?).to eql true
       end
     end
   end
@@ -110,7 +110,7 @@ EOT
 }
 EOT
       provider.class.prefetch(resources)
-      resource.provider.members.should =~ valid_members
+      expect(resource.provider.members).to match_array(valid_members)
     end
   end
 

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -63,13 +63,13 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'exists?' do
     it 'checks if user exists' do
-      provider.exists?.should eql false
+      expect(provider.exists?).to eql false
     end
   end
 
   describe 'password_hash' do
     it 'returns a password_hash' do
-      instance.password_hash.should == "pass"
+      expect(instance.password_hash).to eq("pass")
     end
   end
 
@@ -90,7 +90,7 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'roles' do
     it 'returns a sorted roles' do
-      instance.roles.should == ['role1', 'role2']
+      expect(instance.roles).to eq(['role1', 'role2'])
     end
   end
 

--- a/spec/unit/puppet/type/mongodb_database_spec.rb
+++ b/spec/unit/puppet/type/mongodb_database_spec.rb
@@ -7,12 +7,12 @@ describe Puppet::Type.type(:mongodb_database) do
   end
 
   it 'should accept a database name' do
-    @db[:name].should == 'test'
+    expect(@db[:name]).to eq('test')
   end
 
   it 'should accept a tries parameter' do
     @db[:tries] = 5
-    @db[:tries].should == 5
+    expect(@db[:tries]).to eq(5)
   end
 
   it 'should require a name' do

--- a/spec/unit/puppet/type/mongodb_replset_spec.rb
+++ b/spec/unit/puppet/type/mongodb_replset_spec.rb
@@ -11,12 +11,12 @@ describe Puppet::Type.type(:mongodb_replset) do
   end
 
   it 'should accept a replica set name' do
-    @replset[:name].should == 'test'
+    expect(@replset[:name]).to eq('test')
   end
 
   it 'should accept a members array' do
     @replset[:members] = ['mongo1:27017', 'mongo2:27017']
-    @replset[:members].should == ['mongo1:27017', 'mongo2:27017']
+    expect(@replset[:members]).to eq(['mongo1:27017', 'mongo2:27017'])
   end
 
   it 'should require a name' do

--- a/spec/unit/puppet/type/mongodb_shard_spec.rb
+++ b/spec/unit/puppet/type/mongodb_shard_spec.rb
@@ -7,17 +7,17 @@ describe Puppet::Type.type(:mongodb_shard) do
   end
 
   it 'should accept a shard name' do
-    @shard[:name].should == 'test'
+    expect(@shard[:name]).to eq('test')
   end
 
   it 'should accept a member' do
     @shard[:member] = 'rs_test/mongo1:27017'
-    @shard[:member].should == 'rs_test/mongo1:27017'
+    expect(@shard[:member]).to eq('rs_test/mongo1:27017')
   end
 
   it 'should accept a keys array' do
     @shard[:keys] = [{'foo.bar' => {'name' => 1}}]
-    @shard[:keys].should == [{'foo.bar' => {'name' => 1}}]
+    expect(@shard[:keys]).to eq([{'foo.bar' => {'name' => 1}}])
   end
 
   it 'should require a name' do

--- a/spec/unit/puppet/type/mongodb_user_spec.rb
+++ b/spec/unit/puppet/type/mongodb_user_spec.rb
@@ -10,30 +10,30 @@ describe Puppet::Type.type(:mongodb_user) do
   end
 
   it 'should accept a user name' do
-    @user[:name].should == 'test'
+    expect(@user[:name]).to eq('test')
   end
 
   it 'should accept a database name' do
-    @user[:database].should == 'testdb'
+    expect(@user[:database]).to eq('testdb')
   end
 
   it 'should accept a tries parameter' do
     @user[:tries] = 5
-    @user[:tries].should == 5
+    expect(@user[:tries]).to eq(5)
   end
 
   it 'should accept a password' do
     @user[:password_hash] = 'foo'
-    @user[:password_hash].should == 'foo'
+    expect(@user[:password_hash]).to eq('foo')
   end
 
   it 'should use default role' do
-    @user[:roles].should == ['dbAdmin']
+    expect(@user[:roles]).to eq(['dbAdmin'])
   end
 
   it 'should accept a roles array' do
     @user[:roles] = ['role1', 'role2']
-    @user[:roles].should == ['role1', 'role2']
+    expect(@user[:roles]).to eq(['role1', 'role2'])
   end
 
   it 'should require a name' do
@@ -61,7 +61,7 @@ describe Puppet::Type.type(:mongodb_user) do
               :database => 'testdb',
               :password_hash => 'pass',
               :roles => ['b', 'a'])
-    @user[:roles].should == ['a', 'b']
+    expect(@user[:roles]).to eq(['a', 'b'])
   end
 
 end


### PR DESCRIPTION
This patch aim to update our specs test in order to work with the rspec-puppet
release 2.0.0, in the mean time, we update rspec syntax order to be prepared
for rspec 3.x move.

In details:
* Upgrade and pin rspec-puppet from 1.0.1 to 2.0.0
* Convert 'should' keyword to 'is_expected.to' (prepare rspec 3.x)
* Fix spec tests for rspec-puppet 2.0.0
* Clean Gemfile (remove over-specification of runtime deps of
  puppetlabs_spec_helper)

Signed-off-by: Gael Chamoulaud <gchamoul@redhat.com>