### PR TITLE
Add Puppet 4.x lint checks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,18 @@ group :development, :unit_tests do
   gem 'simplecov',               :require => false
   gem 'puppet_facts',            :require => false
   gem 'json',                    :require => false
+
+  gem 'metadata-json-lint'
+  gem 'puppet-lint-absolute_classname-check'
+  gem 'puppet-lint-absolute_template_path'
+  gem 'puppet-lint-trailing_newline-check'
+
+  # Puppet 4.x related lint checks
+  gem 'puppet-lint-unquoted_string-check'
+  gem 'puppet-lint-leading_zero-check'
+  gem 'puppet-lint-variable_contains_upcase'
+  gem 'puppet-lint-numericvariable'
+
 end
 
 group :system_tests do

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -12,5 +12,5 @@ class mongodb::client (
   $ensure       = $mongodb::params::package_ensure_client,
   $package_name = $mongodb::params::client_package_name,
 ) inherits mongodb::params {
-  class { 'mongodb::client::install': }
+  class { '::mongodb::client::install': }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,7 +101,7 @@ class mongodb (
     settings to mongodb::server. Please verify this works in a safe test
     environment.': }
 
-  class { 'mongodb::server':
+  class { '::mongodb::server':
     package_name    => $packagename,
     logpath         => $logpath,
     logappend       => $logappend,

--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -21,15 +21,15 @@ class mongodb::mongos (
 
   if ($ensure == 'present' or $ensure == true) {
     anchor { 'mongodb::mongos::start': }->
-    class { 'mongodb::mongos::install': }->
-    class { 'mongodb::mongos::config': }->
-    class { 'mongodb::mongos::service': }->
+    class { '::mongodb::mongos::install': }->
+    class { '::mongodb::mongos::config': }->
+    class { '::mongodb::mongos::service': }->
     anchor { 'mongodb::mongos::end': }
   } else {
     anchor { 'mongodb::mongos::start': }->
-    class { 'mongodb::mongos::service': }->
-    class { 'mongodb::mongos::config': }->
-    class { 'mongodb::mongos::install': }->
+    class { '::mongodb::mongos::service': }->
+    class { '::mongodb::mongos::config': }->
+    class { '::mongodb::mongos::install': }->
     anchor { 'mongodb::mongos::end': }
   }
 

--- a/manifests/mongos/service.pp
+++ b/manifests/mongos/service.pp
@@ -10,10 +10,10 @@ class mongodb::mongos::service (
 ) {
 
   $service_ensure_real = $service_ensure ? {
-    absent  => false,
-    purged  => false,
-    stopped => false,
-    default => true
+    'absent'  => false,
+    'purged'  => false,
+    'stopped' => false,
+    default   => true
   }
 
   if $port {
@@ -30,7 +30,7 @@ class mongodb::mongos::service (
 
   if $::osfamily == 'RedHat' {
     file { '/etc/sysconfig/mongos' :
-      ensure  => present,
+      ensure  => file,
       owner   => 'root',
       group   => 'root',
       mode    => '0755',
@@ -40,7 +40,7 @@ class mongodb::mongos::service (
   }
 
   file { '/etc/init.d/mongos' :
-    ensure  => present,
+    ensure  => file,
     content => template("mongodb/mongos/${::osfamily}/mongos.erb"),
     owner   => 'root',
     group   => 'root',

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -17,7 +17,7 @@ class mongodb::repo (
         }
         $description = 'MongoDB/10gen Repository'
       }
-      class { 'mongodb::repo::yum': }
+      class { '::mongodb::repo::yum': }
     }
 
     'Debian': {
@@ -26,7 +26,7 @@ class mongodb::repo (
         'Ubuntu' => 'http://downloads-distro.mongodb.org/repo/ubuntu-upstart',
         default  => undef
       }
-      class { 'mongodb::repo::apt': }
+      class { '::mongodb::repo::apt': }
     }
 
     default: {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -78,15 +78,15 @@ class mongodb::server (
 
   if ($ensure == 'present' or $ensure == true) {
     anchor { 'mongodb::server::start': }->
-    class { 'mongodb::server::install': }->
-    class { 'mongodb::server::config': }->
-    class { 'mongodb::server::service': }->
+    class { '::mongodb::server::install': }->
+    class { '::mongodb::server::config': }->
+    class { '::mongodb::server::service': }->
     anchor { 'mongodb::server::end': }
   } else {
     anchor { 'mongodb::server::start': }->
-    class { 'mongodb::server::service': }->
-    class { 'mongodb::server::config': }->
-    class { 'mongodb::server::install': }->
+    class { '::mongodb::server::service': }->
+    class { '::mongodb::server::config': }->
+    class { '::mongodb::server::install': }->
     anchor { 'mongodb::server::end': }
   }
 }

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -29,10 +29,10 @@ class mongodb::server::service {
   }
 
   $service_ensure = $ensure ? {
-    absent  => false,
-    purged  => false,
-    stopped => false,
-    default => true
+    'absent'  => false,
+    'purged'  => false,
+    'stopped' => false,
+    default   => true
   }
 
   service { 'mongodb':

--- a/tests/client.pp
+++ b/tests/client.pp
@@ -1,2 +1,2 @@
-class { 'mongodb::globals': manage_package_repo => true }->
-class { 'mongodb::client': }
+class { '::mongodb::globals': manage_package_repo => true }->
+class { '::mongodb::client': }

--- a/tests/globals.pp
+++ b/tests/globals.pp
@@ -1,3 +1,3 @@
-class { 'mongodb::globals':
+class { '::mongodb::globals':
   manage_package_repo => true
 }

--- a/tests/server.pp
+++ b/tests/server.pp
@@ -1,2 +1,2 @@
-class { 'mongodb::globals': manage_package_repo => true }->
-class { 'mongodb::server': }
+class { '::mongodb::globals': manage_package_repo => true }->
+class { '::mongodb::server': }


### PR DESCRIPTION
- This changes the puppet-lint requirement to 1.1.x, so that we can use
  puppet-lint plugins. Most of these plugins are for 4.x compat, but some just
  catch common errors.

Signed-off-by: Gael Chamoulaud <gchamoul@redhat.com>