### PR TITLE
Added support for net.http.enabled setting

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -42,6 +42,7 @@ class mongodb::server (
   $oplog_size      = undef,
   $nohints         = undef,
   $nohttpinterface = undef,
+  $nethttpenabled	 = undef,
   $noscripting     = undef,
   $notablescan     = undef,
   $noprealloc      = undef,

--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -96,8 +96,8 @@ net.http.RESTInterfaceEnabled: true
 <% if @maxconns -%>
 net.maxIncomingConnections: <%= @maxconns %>
 <% end -%>
-<% if @nohttpinterface -%>
-net.http.enabled: <%= @nohttpinterface %>
+<% if @nethttpenabled -%>
+net.http.enabled: <%= @nethttpenabled %>
 <% end -%>
 
 #Replication


### PR DESCRIPTION
The current mongodb module manages inconsistently the  net.http.enabled setting in MongoDB 2.6.x.

Setting nohttpinterface to true results in net.http.enabled: true, which I find, based on the name of the setting, inconsistent with the expected behavior.

For this purpose, the nethttpenabled setting was added to support the following configuration
class {'::mongodb::server':
          nethttpenabled => true,
 }

which results in mongo.conf file as 
    net.http.enabled: true

nohttpinterface setting could be still applied to mongo versions older than 2.6.