### PR TITLE
(#1947) Improve support for MongoDB authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ spec/fixtures/
 coverage/
 .idea/
 *.iml
+.ruby-*
+log/

--- a/README.md
+++ b/README.md
@@ -398,6 +398,22 @@ Use this setting to enable shard server mode for mongod.
 Use this setting to configure replication with replica sets. Specify a replica
 set name as an argument to this set. All hosts must have the same set name.
 
+#####`replset_members`
+An array of member hosts for the replica set.
+Mutually exclusive with `replset_config` param.
+
+#####`replset_config`
+A hash that is used to configure the replica set.
+Mutually exclusive with `replset_members` param.
+
+```puppet
+class mongodb::server {
+  replset        => 'rsmain',
+  replset_config => { 'rsmain' => { ensure  => present, members => ['host1:27017', 'host2:27017', 'host3:27017']  }  }
+
+}
+```
+
 #####`rest`
 Set to true to enable a simple REST interface. Default: false
 
@@ -472,6 +488,23 @@ You should not set this for MongoDB versions < 3.x
 
 #####`restart`
 Specifies whether the service should be restarted on config changes. Default: 'true'
+
+#####`create_admin`
+Allows to create admin user for admin database.
+Redefine these parameters if needed:
+
+#####`admin_username`
+Administrator user name
+
+#####`admin_password`
+Administrator user password
+
+#####`admin_roles`
+Administrator user roles
+
+#####`store_creds`
+Store admin credentials in mongorc.js file. Uses with `create_admin` parameter
+
 
 ####Class: mongodb::mongos
 class. This class should only be used if you want to implement sharding within
@@ -564,6 +597,9 @@ The maximum amount of two second tries to wait MongoDB startup. Default: 10
 
 #### Provider: mongodb_user
 'mongodb_user' can be used to create and manage users within MongoDB database.
+
+*Note:* if replica set is enabled, replica initialization has to come before
+any user operations.
 
 ```puppet
 mongodb_user { testuser:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ class {'::mongodb::server': }->
 class {'::mongodb::client': }
 ```
 
+If you don't want to use the 10gen/MongoDB software repository or the OS packages,
+you can point the module to a custom one.
+To install MongoDB from a custom repository:
+
+```puppet
+class {'::mongodb::globals':
+  manage_package_repo => true,
+  repo_location => 'http://example.com/repo'
+}->
+class {'::mongodb::server': }->
+class {'::mongodb::client': }
+```
+
 Having a local copy of MongoDB repository (that is managed by your private modules)
 you can still enjoy the charms of `mongodb::params` that manage packages.
 To disable managing of repository, but still enable managing packages:
@@ -214,6 +227,10 @@ module will use the default for your OS distro.
 The version of MonogDB to install/manage. This is a simple way of providing
 a specific version such as '2.2' or '2.4' for example. If not specified,
 the module will use the default for your OS distro.
+
+#####`repo_location`
+This setting can be used to override the default MongoDB repository location.
+If not specified, the module will use the default repository for your OS distro.
 
 ####Class: mongodb::server
 

--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -26,11 +26,19 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, :parent => Puppet::Provid
   end
 
   def create
-    mongo_eval('db.dummyData.insert({"created_by_puppet": 1})', @resource[:name])
+    if db_ismaster
+      mongo_eval('db.dummyData.insert({"created_by_puppet": 1})', @resource[:name])
+    else
+      Puppet.warning 'Database creation is available only from master host'
+    end
   end
 
   def destroy
-    mongo_eval('db.dropDatabase()', @resource[:name])
+    if db_ismaster
+      mongo_eval('db.dropDatabase()', @resource[:name])
+    else
+      Puppet.warning 'Database removal is available only from master host'
+    end
   end
 
   def exists?

--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -8,35 +8,40 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
   def self.instances
     require 'json'
 
-    if mongo_24?
-      dbs = JSON.parse mongo_eval('printjson(db.getMongo().getDBs()["databases"].map(function(db){return db["name"]}))') || 'admin'
+    if db_ismaster
+      if mongo_24?
+        dbs = JSON.parse mongo_eval('printjson(db.getMongo().getDBs()["databases"].map(function(db){return db["name"]}))') || 'admin'
 
-      allusers = []
+        allusers = []
 
-      dbs.each do |db|
-        users = JSON.parse mongo_eval('printjson(db.system.users.find().toArray())', db)
+        dbs.each do |db|
+          users = JSON.parse mongo_eval('printjson(db.system.users.find().toArray())', db)
 
-        allusers += users.collect do |user|
+          allusers += users.collect do |user|
+              new(:name          => user['_id'],
+                  :ensure        => :present,
+                  :username      => user['user'],
+                  :database      => db,
+                  :roles         => user['roles'].sort,
+                  :password_hash => user['pwd'])
+          end
+        end
+        return allusers
+      else
+        users = JSON.parse mongo_eval('printjson(db.system.users.find().toArray())')
+
+        users.collect do |user|
             new(:name          => user['_id'],
                 :ensure        => :present,
                 :username      => user['user'],
-                :database      => db,
-                :roles         => user['roles'].sort,
-                :password_hash => user['pwd'])
+                :database      => user['db'],
+                :roles         => from_roles(user['roles'], user['db']),
+                :password_hash => user['credentials']['MONGODB-CR'])
         end
       end
-      return allusers
     else
-      users = JSON.parse mongo_eval('printjson(db.system.users.find().toArray())')
-
-      users.collect do |user|
-          new(:name          => user['_id'],
-              :ensure        => :present,
-              :username      => user['user'],
-              :database      => user['db'],
-              :roles         => from_roles(user['roles'], user['db']),
-              :password_hash => user['credentials']['MONGODB-CR'])
-      end
+      Puppet.warning 'User info is available only from master host'
+      return []
     end
   end
 
@@ -53,45 +58,51 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
   mk_resource_methods
 
   def create
+    if db_ismaster
+      if mongo_24?
+        user = {
+          :user => @resource[:username],
+          :pwd => @resource[:password_hash],
+          :roles => @resource[:roles]
+        }
 
+        mongo_eval("db.addUser(#{user.to_json})", @resource[:database])
+      else
+        cmd_json=<<-EOS.gsub(/^\s*/, '').gsub(/$\n/, '')
+        {
+          "createUser": "#{@resource[:username]}",
+          "pwd": "#{@resource[:password_hash]}",
+          "customData": {"createdBy": "Puppet Mongodb_user['#{@resource[:name]}']"},
+          "roles": #{@resource[:roles].to_json},
+          "digestPassword": false
+        }
+        EOS
 
-    if mongo_24?
-      user = {
-        :user => @resource[:username],
-        :pwd => @resource[:password_hash],
-        :roles => @resource[:roles]
-      }
+        mongo_eval("db.runCommand(#{cmd_json})", @resource[:database])
+      end
 
-      mongo_eval("db.addUser(#{user.to_json})", @resource[:database])
+      @property_hash[:ensure] = :present
+      @property_hash[:username] = @resource[:username]
+      @property_hash[:database] = @resource[:database]
+      @property_hash[:password_hash] = ''
+      @property_hash[:rolse] = @resource[:roles]
+
+      exists? ? (return true) : (return false)
     else
-      cmd_json=<<-EOS.gsub(/^\s*/, '').gsub(/$\n/, '')
-      {
-        "createUser": "#{@resource[:username]}",
-        "pwd": "#{@resource[:password_hash]}",
-        "customData": {"createdBy": "Puppet Mongodb_user['#{@resource[:name]}']"},
-        "roles": #{@resource[:roles].to_json},
-        "digestPassword": false
-      }
-      EOS
-
-      mongo_eval("db.runCommand(#{cmd_json})", @resource[:database])
+      Puppet.warning 'User creation is available only from master host'
     end
-
-    @property_hash[:ensure] = :present
-    @property_hash[:username] = @resource[:username]
-    @property_hash[:database] = @resource[:database]
-    @property_hash[:password_hash] = ''
-    @property_hash[:rolse] = @resource[:roles]
-
-    exists? ? (return true) : (return false)
   end
 
 
   def destroy
-    if mongo_24?
-      mongo_eval("db.removeUser('#{@resource[:username]}')")
+    if db_ismaster
+      if mongo_24?
+        mongo_eval("db.removeUser('#{@resource[:username]}')")
+      else
+        mongo_eval("db.dropUser('#{@resource[:username]}')")
+      end
     else
-      mongo_eval("db.dropUser('#{@resource[:username]}')")
+      Puppet.warning 'User removal is available only from master host'
     end
   end
 
@@ -100,30 +111,37 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
   end
 
   def password_hash=(value)
-    cmd_json=<<-EOS.gsub(/^\s*/, '').gsub(/$\n/, '')
-    {
-        "updateUser": "#{@resource[:username]}",
-        "pwd": "#{@resource[:password_hash]}",
-        "digestPassword": false
-    }
-    EOS
-
-    mongo_eval("db.runCommand(#{cmd_json})", @resource[:database])
+    if db_ismaster
+      cmd_json=<<-EOS.gsub(/^\s*/, '').gsub(/$\n/, '')
+      {
+          "updateUser": "#{@resource[:username]}",
+          "pwd": "#{@resource[:password_hash]}",
+          "digestPassword": false
+      }
+      EOS
+      mongo_eval("db.runCommand(#{cmd_json})", @resource[:database])
+    else
+      Puppet.warning 'User password operations are available only from master host'
+    end
   end
 
   def roles=(roles)
-    if mongo_24?
-      mongo_eval("db.system.users.update({user:'#{@resource[:username]}'}, { $set: {roles: #{@resource[:roles].to_json}}})")
-    else
-      grant = roles-@resource[:roles]
-      if grant.length > 0
-        mongo_eval("db.getSiblingDB('#{@resource[:database]}').grantRolesToUser('#{@resource[:username]}', #{grant. to_json})")
-      end
+    if db_ismaster
+      if mongo_24?
+        mongo_eval("db.system.users.update({user:'#{@resource[:username]}'}, { $set: {roles: #{@resource[:roles].to_json}}})")
+      else
+        grant = roles-@resource[:roles]
+        if grant.length > 0
+          mongo_eval("db.getSiblingDB('#{@resource[:database]}').grantRolesToUser('#{@resource[:username]}', #{grant. to_json})")
+        end
 
-      revoke = @resource[:roles]-roles
-      if revoke.length > 0
-        mongo_eval("db.getSiblingDB('#{@resource[:database]}').revokeRolesFromUser('#{@resource[:username]}', #{revoke.to_json})")
+        revoke = @resource[:roles]-roles
+        if revoke.length > 0
+          mongo_eval("db.getSiblingDB('#{@resource[:database]}').revokeRolesFromUser('#{@resource[:username]}', #{revoke.to_json})")
+        end
       end
+    else
+      Puppet.warning 'User roles operations are available only from master host'
     end
   end
 

--- a/lib/puppet/type/mongodb_replset.rb
+++ b/lib/puppet/type/mongodb_replset.rb
@@ -21,6 +21,11 @@ Puppet::Type.newtype(:mongodb_replset) do
     desc "The replicaSet arbiter"
   end
 
+  newparam(:initialize_host) do
+    desc "Host to use for Replicaset initialization"
+    defaultto '127.0.0.1'
+  end
+
   newproperty(:members, :array_matching => :all) do
     desc "The replicaSet members"
 

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -19,9 +19,8 @@ define mongodb::db (
 ) {
 
   mongodb_database { $name:
-    ensure  => present,
-    tries   => $tries,
-    require => Class['mongodb::server'],
+    ensure => present,
+    tries  => $tries
   }
 
   if $password_hash {

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -30,6 +30,8 @@ class mongodb::globals (
 
   $repo_location         = undef,
   $use_enterprise_repo   = undef,
+
+  $pidfilepath           = undef,
 ) {
 
   # Setup of the repo only makes sense globally, so we are doing it here.

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -28,13 +28,15 @@ class mongodb::globals (
   $manage_package_repo   = undef,
   $manage_package        = undef,
 
+  $repo_location         = undef,
   $use_enterprise_repo   = undef,
 ) {
 
   # Setup of the repo only makes sense globally, so we are doing it here.
   if($manage_package_repo) {
     class { '::mongodb::repo':
-      ensure  => present,
+      ensure        => present,
+      repo_location => $repo_location,
     }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,6 @@ class mongodb (
   $enable_10gen    = undef,
 
   $init            = $mongodb::params::service_provider,
-  $location        = '',
   $packagename     = undef,
   $version         = undef,
   $servicename     = $mongodb::params::service_name,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,10 @@ class mongodb::params inherits mongodb::globals {
   $service_ensure        = pick($mongodb::globals::service_ensure, 'running')
   $service_status        = $mongodb::globals::service_status
   $restart               = true
+  $create_admin          = false
+  $admin_username        = 'admin'
+  $store_creds           = false
+  $rcfile                = "${::root_home}/.mongorc.js"
 
   $mongos_service_manage = pick($mongodb::globals::mongos_service_manage, true)
   $mongos_service_enable = pick($mongodb::globals::mongos_service_enable, true)

--- a/manifests/replset.pp
+++ b/manifests/replset.pp
@@ -7,4 +7,9 @@ class mongodb::replset(
   if $sets {
     create_resources(mongodb_replset, $sets)
   }
+
+  # Order replset before any DB's and shard config
+  Mongodb_replset <| |> -> Mongodb_database <| |>
+  Mongodb_replset <| |> -> Mongodb_shard <| |>
+  Mongodb_replset <| |> -> Mongodb_user <| |>
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,11 +1,15 @@
 # PRIVATE CLASS: do not use directly
 class mongodb::repo (
-  $ensure  = $mongodb::params::ensure,
-  $version = $mongodb::params::version,
+  $ensure        = $mongodb::params::ensure,
+  $version       = $mongodb::params::version,
+  $repo_location = undef,
 ) inherits mongodb::params {
   case $::osfamily {
     'RedHat', 'Linux': {
-      if $mongodb::globals::use_enterprise_repo == true {
+      if ($repo_location != undef){
+        $location = $repo_location
+        $description = 'MongoDB Custom Repository'
+      } elsif $mongodb::globals::use_enterprise_repo == true {
         $location = 'https://repo.mongodb.com/yum/redhat/$releasever/mongodb-enterprise/stable/$basearch/'
         $description = 'MongoDB Enterprise Repository'
       }
@@ -25,14 +29,19 @@ class mongodb::repo (
         }
         $description = 'MongoDB/10gen Repository'
       }
+
       class { '::mongodb::repo::yum': }
     }
 
     'Debian': {
-      $location = $::operatingsystem ? {
-        'Debian' => 'http://downloads-distro.mongodb.org/repo/debian-sysvinit',
-        'Ubuntu' => 'http://downloads-distro.mongodb.org/repo/ubuntu-upstart',
-        default  => undef
+      if ($repo_location != undef){
+        $location = $repo_location
+      }else{
+        $location = $::operatingsystem ? {
+          'Debian' => 'http://downloads-distro.mongodb.org/repo/debian-sysvinit',
+          'Ubuntu' => 'http://downloads-distro.mongodb.org/repo/ubuntu-upstart',
+          default  => undef
+        }
       }
       class { '::mongodb::repo::apt': }
     }

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -6,7 +6,7 @@ class mongodb::repo::apt inherits mongodb::repo {
   include ::apt
 
   if($::mongodb::repo::ensure == 'present' or $::mongodb::repo::ensure == true) {
-    apt::source { 'downloads-distro.mongodb.org':
+    apt::source { 'mongodb':
       location    => $::mongodb::repo::location,
       release     => 'dist',
       repos       => '10gen',
@@ -15,10 +15,10 @@ class mongodb::repo::apt inherits mongodb::repo {
       include_src => false,
     }
 
-    Apt::Source['downloads-distro.mongodb.org']->Package<|tag == 'mongodb'|>
+    Apt::Source['mongodb']->Package<|tag == 'mongodb'|>
   }
   else {
-    apt::source { 'downloads-distro.mongodb.org':
+    apt::source { 'mongodb':
       ensure => absent,
     }
   }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -18,6 +18,11 @@ class mongodb::server::config {
   $cpu             = $mongodb::server::cpu
   $auth            = $mongodb::server::auth
   $noath           = $mongodb::server::noauth
+  $create_admin    = $mongodb::server::create_admin
+  $admin_username  = $mongodb::server::admin_username
+  $admin_password  = $mongodb::server::admin_password
+  $store_creds     = $mongodb::server::store_creds
+  $rcfile          = $mongodb::server::rcfile
   $verbose         = $mongodb::server::verbose
   $verbositylevel  = $mongodb::server::verbositylevel
   $objcheck        = $mongodb::server::objcheck
@@ -208,6 +213,20 @@ class mongodb::server::config {
       backup => false,
     }
     file { $config:
+      ensure => absent
+    }
+  }
+
+  if $auth and $store_creds {
+    file { $rcfile:
+      ensure  => present,
+      content => template('mongodb/mongorc.js.erb'),
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644'
+    }
+  } else {
+    file { $rcfile:
       ensure => absent
     }
   }

--- a/spec/acceptance/replset_spec.rb
+++ b/spec/acceptance/replset_spec.rb
@@ -9,10 +9,14 @@ if hosts.length > 1
       pp = <<-EOS
         class { 'mongodb::globals': }
         -> class { 'mongodb::server':
-          ensure => purged,
+          ensure         => absent,
+          package_ensure => absent,
+          service_ensure => stopped
         }
         if $::osfamily == 'RedHat' {
-          class { 'mongodb::client': }
+          class { 'mongodb::client':
+            ensure => absent
+          }
         }
       EOS
 
@@ -63,6 +67,135 @@ if hosts.length > 1
       sleep(10)
       on hosts_as('slave'), %{mongo --verbose --eval 'rs.slaveOk(); printjson(db.test.findOne({name:"test1"}))'} do |r|
         expect(r.stdout).to match /some value/
+      end
+    end
+  end
+
+  describe 'mongodb_replset resource with auth => true' do
+    after :all do
+      # Have to drop the DB to disable replsets for further testing
+      on hosts, %{mongo local --verbose --eval 'db.dropDatabase()'}
+
+      pp = <<-EOS
+        class { 'mongodb::globals': }
+        -> class { 'mongodb::server':
+          ensure => absent,
+          package_ensure => absent,
+          service_ensure => stopped
+        }
+        if $::osfamily == 'RedHat' {
+          class { 'mongodb::client':
+            ensure => absent
+          }
+        }
+      EOS
+
+      apply_manifest_on(hosts.reverse, pp, :catch_failures => true)
+    end
+
+    it 'configures mongo on both nodes' do
+      pp = <<-EOS
+        class { 'mongodb::globals':
+          version             => '2.6.9-1',
+          manage_package_repo => true
+        } ->
+        class { 'mongodb::server':
+          admin_username => 'admin',
+          admin_password => 'password',
+          auth           => true,
+          bind_ip        => '0.0.0.0',
+          replset        => 'test',
+          keyfile        => '/var/lib/mongodb/mongodb-keyfile',
+          key            => '+dxlTrury7xtD0FRqFf3YWGnKqWAtlyauuemxuYuyz9POPUuX1Uj3chGU8MFMHa7
+UxASqex7NLMALQXHL+Th4T3dyb6kMZD7KiMcJObO4M+JLiX9drcTiifsDEgGMi7G
+vYn3pWSm5TTDrHJw7RNWfMHw3sHk0muGQcO+0dWv3sDJ6SiU8yOKRtYcTEA15GbP
+ReDZuHFy1T1qhk5NIt6pTtPGsZKSm2wAWIOa2f2IXvpeQHhjxP8aDFb3fQaCAqOD
+R7hrimqq0Nickfe8RLA89iPXyadr/YeNBB7w7rySatQBzwIbBUVGNNA5cxCkwyx9
+E5of3xi7GL9xNxhQ8l0JEpofd4H0y0TOfFDIEjc7cOnYlKAHzBgog4OcFSILgUaF
+kHuTMtv0pj+MMkW2HkeXETNII9XE1+JiZgHY08G7yFEJy87ttUoeKmpbI6spFz5U
+4K0amj+N6SOwXaS8uwp6kCqay0ERJLnw+7dKNKZIZdGCrrBxcZ7wmR/wLYrxvHhZ
+QpeXTxgD5ebwCR0cf3Xnb5ql5G/HHKZDq8LTFHwELNh23URGPY7K7uK+IF6jSEhq
+V2H3HnWV9teuuJ5he9BB/pLnyfjft6KUUqE9HbaGlX0f3YBk/0T3S2ESN4jnfRTQ
+ysAKvQ6NasXkzqXktu8X4fS5QNqrFyqKBZSWxttfJBKXnT0TxamCKLRx4AgQglYo
+3KRoyfxXx6G+AjP1frDJxFAFEIgEFqRk/FFuT/y9LpU+3cXYX1Gt6wEatgmnBM3K
+g+Bybk5qHv1b7M8Tv9/I/BRXcpLHeIkMICMY8sVPGmP8xzL1L3i0cws8p5h0zPBa
+YG/QX0BmltAni8owgymFuyJgvr/gaRX4WHbKFD+9nKpqJ3ocuVNuCDsxDqLsJEME
+nc1ohyB0lNt8lHf1U00mtgDSV3fwo5LkwhRi6d+bDBTL/C6MZETMLdyCqDlTdUWG
+YXIsJ0gYcu9XG3mx10LbdPJvxSMg'
+ 
+        }
+        if $::osfamily == 'RedHat' {
+          include mongodb::client
+        }
+      EOS
+
+      apply_manifest_on(hosts.reverse, pp, :catch_failures => true)
+      apply_manifest_on(hosts.reverse, pp, :catch_changes  => true)
+    end
+
+    it 'sets up the replset with puppet' do
+      pp = <<-EOS
+        class { 'mongodb::globals':
+          version             => '2.6.9-1',
+          manage_package_repo => true
+        } ->
+        class { 'mongodb::server':
+          create_admin   => true,
+          admin_username => 'admin',
+          admin_password => 'password',
+          auth           => true,
+          bind_ip        => '0.0.0.0',
+          replset        => 'test',
+          keyfile        => '/var/lib/mongodb/mongodb-keyfile',
+          key            => '+dxlTrury7xtD0FRqFf3YWGnKqWAtlyauuemxuYuyz9POPUuX1Uj3chGU8MFMHa7
+UxASqex7NLMALQXHL+Th4T3dyb6kMZD7KiMcJObO4M+JLiX9drcTiifsDEgGMi7G
+vYn3pWSm5TTDrHJw7RNWfMHw3sHk0muGQcO+0dWv3sDJ6SiU8yOKRtYcTEA15GbP
+ReDZuHFy1T1qhk5NIt6pTtPGsZKSm2wAWIOa2f2IXvpeQHhjxP8aDFb3fQaCAqOD
+R7hrimqq0Nickfe8RLA89iPXyadr/YeNBB7w7rySatQBzwIbBUVGNNA5cxCkwyx9
+E5of3xi7GL9xNxhQ8l0JEpofd4H0y0TOfFDIEjc7cOnYlKAHzBgog4OcFSILgUaF
+kHuTMtv0pj+MMkW2HkeXETNII9XE1+JiZgHY08G7yFEJy87ttUoeKmpbI6spFz5U
+4K0amj+N6SOwXaS8uwp6kCqay0ERJLnw+7dKNKZIZdGCrrBxcZ7wmR/wLYrxvHhZ
+QpeXTxgD5ebwCR0cf3Xnb5ql5G/HHKZDq8LTFHwELNh23URGPY7K7uK+IF6jSEhq
+V2H3HnWV9teuuJ5he9BB/pLnyfjft6KUUqE9HbaGlX0f3YBk/0T3S2ESN4jnfRTQ
+ysAKvQ6NasXkzqXktu8X4fS5QNqrFyqKBZSWxttfJBKXnT0TxamCKLRx4AgQglYo
+3KRoyfxXx6G+AjP1frDJxFAFEIgEFqRk/FFuT/y9LpU+3cXYX1Gt6wEatgmnBM3K
+g+Bybk5qHv1b7M8Tv9/I/BRXcpLHeIkMICMY8sVPGmP8xzL1L3i0cws8p5h0zPBa
+YG/QX0BmltAni8owgymFuyJgvr/gaRX4WHbKFD+9nKpqJ3ocuVNuCDsxDqLsJEME
+nc1ohyB0lNt8lHf1U00mtgDSV3fwo5LkwhRi6d+bDBTL/C6MZETMLdyCqDlTdUWG
+YXIsJ0gYcu9XG3mx10LbdPJvxSMg'
+        }
+        if $::osfamily == 'RedHat' {
+          include mongodb::client
+        }
+        mongodb_replset { 'test':
+          auth_enabled => true,
+          members      => [#{hosts.collect{|x|"'#{x}:27017'"}.join(',')}],
+          before       => Mongodb_user['admin']
+        }
+      EOS
+      apply_manifest_on(hosts_as('master'), pp, :catch_failures => true)
+      apply_manifest_on(hosts_as('master'), pp, :catch_changes => true)
+      on(hosts_as('master'), 'mongo --quiet --eval "load(\'/root/.mongorc.js\');printjson(rs.conf())"') do |r|
+        expect(r.stdout).to match /#{hosts[0]}:27017/
+        expect(r.stdout).to match /#{hosts[1]}:27017/
+      end
+    end
+
+    it 'inserts data on the master' do
+      sleep(30)
+      on hosts_as('master'), %{mongo test --verbose --eval 'load("/root/.mongorc.js");db.dummyData.insert({"created_by_puppet": 1})'}
+    end
+
+    it 'checks the data on the master' do
+      on hosts_as('master'), %{mongo test --verbose --eval 'load("/root/.mongorc.js");printjson(db.dummyData.findOne())'} do |r|
+        expect(r.stdout).to match /created_by_puppet/
+      end
+    end
+
+    it 'checks the data on the slave' do
+      sleep(10)
+      on hosts_as('slave'), %{mongo test --verbose --eval 'load("/root/.mongorc.js");rs.slaveOk();printjson(db.dummyData.findOne())'} do |r|
+        expect(r.stdout).to match /created_by_puppet/
       end
     end
   end

--- a/spec/acceptance/server_spec.rb
+++ b/spec/acceptance/server_spec.rb
@@ -117,6 +117,119 @@ describe 'mongodb::server class' do
     end
   end
 
+  shared_examples 'auth tests' do |tengen|
+    if tengen
+      case fact('osfamily')
+      when 'RedHat'
+        package_name = 'mongodb-org-server'
+        service_name = 'mongod'
+        config_file  = '/etc/mongod.conf'
+      when 'Debian'
+        package_name = 'mongodb-org-server'
+        service_name = 'mongod'
+        config_file  = '/etc/mongod.conf'
+      end
+    else
+      case fact('osfamily')
+      when 'RedHat'
+        package_name = 'mongodb-server'
+        service_name = 'mongod'
+        config_file  = '/etc/mongodb.conf'
+      when 'Debian'
+        package_name = 'mongodb-server'
+        service_name = 'mongodb'
+        config_file  = '/etc/mongodb.conf'
+      end
+    end
+
+    client_name  = 'mongo --version'
+
+    auth_enabled = 'mongo --quiet --eval "db.serverCmdLineOpts().code"'
+    admin_login = "mongo admin --quiet --eval \"load('/root/.mongorc.js');printjson(db.getUser('admin')['customData'])\""
+
+    context "default parameters with 10gen => #{tengen} and auth => true" do
+      it 'should work with no errors with authentication enabled' do
+        pp = <<-EOS
+          class { 'mongodb::globals': manage_package_repo => #{tengen}, }
+          -> class { 'mongodb::server':
+            auth           => true,
+            create_admin   => true,
+            store_creds    => true,
+            admin_username => 'admin',
+            admin_password => 'password'
+          }
+          class { 'mongodb::client': }
+        EOS
+
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes  => true)
+      end
+
+      describe package(package_name) do
+        it { is_expected.to be_installed }
+      end
+
+      describe file(config_file) do
+        it { is_expected.to be_file }
+      end
+
+      describe service(service_name) do
+         it { is_expected.to be_enabled }
+         it { is_expected.to be_running }
+      end
+
+      describe port(27017) do
+        it { is_expected.to be_listening }
+      end
+
+      describe command(auth_enabled) do
+        describe '#stdout' do
+          subject { super().stdout.strip }
+          it { is_expected.to eq "13" }
+        end
+      end
+
+      describe file('/root/.mongorc.js') do
+        it { is_expected.to be_file }
+        it { is_expected.to be_owned_by 'root' }
+        it { is_expected.to be_grouped_into 'root' }
+        it { is_expected.to be_mode 644 }
+        it { is_expected.to contain 'db.auth(\'admin\', \'password\')' }
+      end
+
+      describe command(admin_login) do
+        describe '#stdout' do
+          subject { super().stdout.strip }
+          it { is_expected.to match "{ \"createdBy\" : \"Puppet Mongodb_user['User admin on db admin']\" }"}
+        end
+      end
+
+      describe command(client_name) do
+        describe '#exit_status' do
+          subject { super().exit_status }
+          it { is_expected.to eq 0 }
+        end
+      end
+    end
+
+    describe "uninstalling with 10gen => #{tengen}" do
+      it 'uninstalls mongodb' do
+        pp = <<-EOS
+          class {'mongodb::globals': manage_package_repo => #{tengen}, }
+          -> class { 'mongodb::server':
+               ensure => absent,
+               package_ensure => absent,
+               service_ensure => stopped,
+               service_enable => false
+             }
+          -> class { 'mongodb::client': ensure => absent, }
+        EOS
+        apply_manifest(pp, :catch_failures => true)
+      end
+    end
+  end
+
   it_behaves_like 'normal tests', false
   it_behaves_like 'normal tests', true
+  it_behaves_like 'auth tests', true
 end

--- a/spec/classes/server_config_spec.rb
+++ b/spec/classes/server_config_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'mongodb::server::config', :type => :class do
 
   describe 'with preseted variables' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' }", "include mongodb::server"]}
+    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' }", "include mongodb::server"]}
 
     it {
       is_expected.to contain_file('/etc/mongod.conf')
@@ -12,7 +12,7 @@ describe 'mongodb::server::config', :type => :class do
   end
 
   describe 'with default values' do
-    let(:pre_condition) {[ "class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $user = 'mongod' $group = 'mongod' $port = 29017 $bind_ip = ['0.0.0.0'] $fork = true $logpath ='/var/log/mongo/mongod.log' $logappend = true }",  "include mongodb::server" ]}
+    let(:pre_condition) {[ "class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $create_admin = false $rcfile = '/root/.mongorc.js' $store_creds = true $ensure = present $user = 'mongod' $group = 'mongod' $port = 29017 $bind_ip = ['0.0.0.0'] $fork = true $logpath ='/var/log/mongo/mongod.log' $logappend = true }",  "include mongodb::server" ]}
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with({
@@ -27,11 +27,13 @@ describe 'mongodb::server::config', :type => :class do
       is_expected.to contain_file('/etc/mongod.conf').with_content(/^logappend=true/)
       is_expected.to contain_file('/etc/mongod.conf').with_content(/^logpath=\/var\/log\/mongo\/mongod\.log/)
       is_expected.to contain_file('/etc/mongod.conf').with_content(/^fork=true/)
+
+      is_expected.to contain_file('/root/.mongorc.js').with({ :ensure => 'absent' })
     }
   end
 
   describe 'with absent ensure' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = absent }", "include mongodb::server"]}
+    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = absent }", "include mongodb::server"]}
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with({ :ensure => 'absent' })
@@ -40,7 +42,7 @@ describe 'mongodb::server::config', :type => :class do
   end
 
   describe 'when specifying storage_engine' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $version='3.0.3' $storage_engine = 'SomeEngine' $storage_engine_internal = 'SomeEngine' $user = 'mongod' $group = 'mongod' $port = 29017 $bind_ip = ['0.0.0.0'] $fork = true $logpath ='/var/log/mongo/mongod.log' $logappend = true}", "include mongodb::server"]}
+    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.monogrc.js' $ensure = present $version='3.0.3' $storage_engine = 'SomeEngine' $storage_engine_internal = 'SomeEngine' $user = 'mongod' $group = 'mongod' $port = 29017 $bind_ip = ['0.0.0.0'] $fork = true $logpath ='/var/log/mongo/mongod.log' $logappend = true}", "include mongodb::server"]}
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with_content(/storage.engine:\sSomeEngine/)
@@ -48,7 +50,7 @@ describe 'mongodb::server::config', :type => :class do
   end
 
   describe 'with specific bind_ip values and ipv6' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $bind_ip = ['127.0.0.1', 'fd00:beef:dead:55::143'] $ipv6 = true }", "include mongodb::server"]}
+    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $bind_ip = ['127.0.0.1', 'fd00:beef:dead:55::143'] $ipv6 = true }", "include mongodb::server"]}
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with_content(/bind_ip\s=\s127\.0\.0\.1\,fd00:beef:dead:55::143/)
@@ -57,7 +59,7 @@ describe 'mongodb::server::config', :type => :class do
   end
 
   describe 'with specific bind_ip values' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $bind_ip = ['127.0.0.1', '10.1.1.13']}", "include mongodb::server"]}
+    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $bind_ip = ['127.0.0.1', '10.1.1.13']}", "include mongodb::server"]}
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with_content(/bind_ip\s=\s127\.0\.0\.1\,10\.1\.1\.13/)
@@ -65,15 +67,16 @@ describe 'mongodb::server::config', :type => :class do
   end
 
   describe 'when specifying auth to true' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $auth = true $dbpath = '/var/lib/mongo' $ensure = present }", "include mongodb::server"]}
+    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $auth = true $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present }", "include mongodb::server"]}
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with_content(/^auth=true/)
+      is_expected.to contain_file('/root/.mongorc.js')
     }
   end
   
   describe 'when specifying set_parameter value' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $set_parameter = 'textSearchEnable=true' $dbpath = '/var/lib/mongo' $ensure = present }", "include mongodb::server"]}
+    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $set_parameter = 'textSearchEnable=true' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present }", "include mongodb::server"]}
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with_content(/^setParameter = textSearchEnable=true/)
@@ -82,7 +85,7 @@ describe 'mongodb::server::config', :type => :class do
 
   describe 'with journal:' do
     context 'on true with i686 architecture' do
-      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $journal = true }", "include mongodb::server"]}
+      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $journal = true }", "include mongodb::server"]}
       let (:facts) { { :architecture => 'i686' } }
 
       it {
@@ -95,14 +98,14 @@ describe 'mongodb::server::config', :type => :class do
   describe 'with quota to' do
 
     context 'true and without quotafiles' do
-      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $quota = true }", "include mongodb::server"]}
+      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $quota = true }", "include mongodb::server"]}
       it {
         is_expected.to contain_file('/etc/mongod.conf').with_content(/^quota = true/)
       }
     end
 
     context 'true and with quotafiles' do
-      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $quota = true $quotafiles = 1 }", "include mongodb::server"]}
+      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $quota = true $quotafiles = 1 }", "include mongodb::server"]}
 
       it {
         is_expected.to contain_file('/etc/mongod.conf').with_content(/quota = true/)
@@ -113,7 +116,7 @@ describe 'mongodb::server::config', :type => :class do
 
   describe 'when specifying syslog value' do
     context 'it should be set to true' do
-      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $syslog = true }", "include mongodb::server"]}
+      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $syslog = true }", "include mongodb::server"]}
 
       it {
         is_expected.to contain_file('/etc/mongod.conf').with_content(/^syslog = true/)
@@ -121,13 +124,36 @@ describe 'mongodb::server::config', :type => :class do
     end
 
     context 'if logpath is also set an error should be raised' do
-      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $ensure = present $syslog = true $logpath ='/var/log/mongo/mongod.log' }", "include mongodb::server"]}
+      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $syslog = true $logpath ='/var/log/mongo/mongod.log' }", "include mongodb::server"]}
 
       it {
         expect { is_expected.to contain_file('/etc/mongod.conf') }.to raise_error(Puppet::Error, /You cannot use syslog with logpath/)
       }
     end
 
+  end
+
+  describe 'with store_creds' do
+    context 'true' do 
+      let(:pre_condition) { ["class mongodb::server { $admin_username = 'admin' $admin_password = 'password' $auth = true $store_creds = true $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present }", "include mongodb::server"]}
+
+      it {
+        is_expected.to contain_file('/root/.mongorc.js').
+          with_ensure('present').
+          with_owner('root').
+          with_group('root').
+          with_mode('0644').
+          with_content(/db.auth\('admin', 'password'\)/)
+      }
+    end
+
+    context 'false' do
+      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $store_creds = false  }", "include mongodb::server"]}
+
+      it {
+        is_expected.to contain_file('/root/.mongorc.js').with_ensure('absent')
+      }
+    end
   end
 
 end

--- a/spec/defines/db_spec.rb
+++ b/spec/defines/db_spec.rb
@@ -10,8 +10,7 @@ describe 'mongodb::db', :type => :define do
   }
 
   it 'should contain mongodb_database with mongodb::server requirement' do
-    is_expected.to contain_mongodb_database('testdb')\
-      .with_require('Class[Mongodb::Server]')
+    is_expected.to contain_mongodb_database('testdb')
   end
 
   it 'should contain mongodb_user with mongodb_database requirement' do

--- a/spec/unit/puppet/provider/mongodb_database/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_database/mongodb_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'tempfile'
 
 describe Puppet::Type.type(:mongodb_database).provider(:mongodb) do
 
@@ -32,7 +33,11 @@ describe Puppet::Type.type(:mongodb_database).provider(:mongodb) do
   let(:provider) { resource.provider }
 
   before :each do
+    tmp = Tempfile.new('test')
+    @mongodconffile = tmp.path
+    allow(provider.class).to receive(:get_mongod_conf_file).and_return(@mongodconffile)
     provider.class.stubs(:mongo_eval).with('printjson(db.getMongo().getDBs())').returns(raw_dbs)
+    allow(provider.class).to receive(:db_ismaster).and_return(true)
   end
 
   let(:instance) { provider.class.instances.first }

--- a/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
@@ -22,13 +22,29 @@ describe Puppet::Type.type(:mongodb_replset).provider(:mongo) do
   let(:provider) { described_class.new(resource) }
 
   describe '#create' do
+    before :each do
+      tmp = Tempfile.new('test')
+      @mongodconffile = tmp.path
+      allow(provider.class).to receive(:get_mongod_conf_file).and_return(@mongodconffile)
+      allow(provider.class).to receive(:mongo).and_return(<<EOT)
+{
+        "ismaster" : false,
+        "secondary" : false,
+        "info" : "can't get local.system.replset config from self or any seed (EMPTYCONFIG)",
+        "isreplicaset" : true
+}
+EOT
+    end
+
     it 'should create a replicaset' do
       allow(provider.class).to receive(:get_replset_properties)
       allow(provider).to receive(:alive_members).and_return(valid_members)
+      allow(provider).to receive(:master_host).and_return(false)
       expect(provider).to receive('rs_initiate').with("{ _id: \"rs_test\", members: [ { _id: 0, host: \"mongo1:27017\" },{ _id: 1, host: \"mongo2:27017\" },{ _id: 2, host: \"mongo3:27017\" } ] }", "mongo1:27017").and_return({
         "info" => "Config now saved locally.  Should come online in about a minute.",
         "ok"   => 1,
       })
+      allow(provider).to receive(:db_ismaster).and_return('{"ismaster" : true}')
       provider.create
       provider.flush
     end
@@ -36,11 +52,13 @@ describe Puppet::Type.type(:mongodb_replset).provider(:mongo) do
     it 'should create a replicaset with arbiter' do
       allow(provider.class).to receive(:get_replset_properties)
       allow(provider).to receive(:alive_members).and_return(valid_members)
+      allow(provider).to receive(:master_host).and_return(false)
       allow(provider).to receive(:rs_arbiter).and_return('mongo3:27017')
       expect(provider).to receive('rs_initiate').with("{ _id: \"rs_test\", members: [ { _id: 0, host: \"mongo1:27017\" },{ _id: 1, host: \"mongo2:27017\" },{ _id: 2, host: \"mongo3:27017\", arbiterOnly: \"true\" } ] }", "mongo1:27017").and_return({
         "info" => "Config now saved locally.  Should come online in about a minute.",
         "ok"   => 1,
       })
+      allow(provider).to receive(:db_ismaster).and_return('{"ismaster" : true}')
       provider.create
       provider.flush
     end
@@ -52,9 +70,10 @@ describe Puppet::Type.type(:mongodb_replset).provider(:mongo) do
       @mongodconffile = tmp.path
       allow(provider.class).to receive(:get_mongod_conf_file).and_return(@mongodconffile)
     end
+
     describe 'when the replicaset does not exist' do
       it 'returns false' do
-        allow(provider.class).to receive(:mongo).and_return(<<EOT)
+        allow(provider.class).to receive(:mongo_eval).and_return(<<EOT)
 {
 	"startupStatus" : 3,
 	"info" : "run rs.initiate(...) if not yet done for the set",
@@ -69,7 +88,7 @@ EOT
 
     describe 'when the replicaset exists' do
       it 'returns true' do
-        allow(provider.class).to receive(:mongo).and_return(<<EOT)
+        allow(provider.class).to receive(:mongo_eval).and_return(<<EOT)
 {
 	"_id" : "rs_test",
 	"version" : 1,
@@ -89,7 +108,7 @@ EOT
       allow(provider.class).to receive(:get_mongod_conf_file).and_return(@mongodconffile)
     end
     it 'returns the members of a configured replicaset' do
-      allow(provider.class).to receive(:mongo).and_return(<<EOT)
+      allow(provider.class).to receive(:mongo_eval).and_return(<<EOT)
 {
 	"_id" : "rs_test",
 	"version" : 1,
@@ -121,7 +140,7 @@ EOT
       allow(provider.class).to receive(:get_mongod_conf_file).and_return(@mongodconffile)
     end
     before :each do
-      allow(provider.class).to receive(:mongo).and_return(<<EOT)
+      allow(provider.class).to receive(:mongo_eval).and_return(<<EOT)
 {
 	"setName" : "rs_test",
 	"ismaster" : true,
@@ -141,7 +160,7 @@ EOT
 
     it 'adds missing members to an existing replicaset' do
       allow(provider.class).to receive(:get_replset_properties)
-      allow(provider).to receive(:rs_status).and_return({ "set" => "rs_test" })
+      allow(provider).to receive(:rs_status).and_return({ 'set' => 'rs_test' })
       expect(provider).to receive('rs_add').twice.and_return({ 'ok' => 1 })
       provider.members=(valid_members)
       provider.flush

--- a/templates/mongorc.js.erb
+++ b/templates/mongorc.js.erb
@@ -1,0 +1,27 @@
+function authRequired() {
+  try {
+    if (db.serverCmdLineOpts().code == 13) {
+      return true;
+    }
+    return false;
+  }
+  catch (err) {
+    return false;
+  }
+}
+
+if (authRequired()) {
+  try {
+<% if @replset -%>
+    rs.slaveOk()
+<% end -%>
+    var prev_db = db
+    db = db.getSiblingDB('admin')
+    db.auth('<%= @admin_username %>', '<%= @admin_password %>')
+    db = db.getSiblingDB(prev_db)
+  }
+  catch (err) {
+    // This isn't catching authentication errors as I'd expect...
+    return;
+  }
+}


### PR DESCRIPTION
Improve support for MongoDB authentication by:
* Creating an 'administration' user. 
* Store those credentials in '.mongorc.js', which is used by Puppet to authenticate
* Add some tests for this functionality. 