### PR TITLE
Be able to specify storageEngine to be used by mongodb

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -63,6 +63,7 @@ class mongodb::server (
   $ssl             = undef,
   $ssl_key         = undef,
   $ssl_ca          = undef,
+  $storage_engine  = undef,
 
   # Deprecated parameters
   $master          = undef,

--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -177,6 +177,9 @@ keyFile = <%= @keyfile %>
 <% if @set_parameter -%>
 setParameter = <%= @set_parameter %>
 <% end -%>
+<% if @storage_engine -%>
+storageEngine = <%= @storage_engine %>
+<% end -%>
 <% if @syslog -%>
 syslog = <%= @syslog %>
 <% end -%>


### PR DESCRIPTION
, its new config option introduced in 3.0