### PR TITLE
Allow one to remove the service from the catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ This setting can be used to override the default status check command for
 your MongoDB service. If not specified, the module will use whatever service
 name is the default for your OS distro.
 
+##### `mongod_service_manage`
+This setting can be used to override the default management of the mongod service.
+By default the module will manage the mongod process.
+
+##### `mongos_service_manage`
+This setting can be used to override the default management of the mongos service.
+By default the module will manage the mongos process.
+
 #####`user`
 This setting can be used to override the default MongoDB user and owner of the
 service and related files in the file system. If not specified, the module will
@@ -422,6 +430,11 @@ Default: <>
 #####`ssl_ca`
 Default: <>
 
+
+#####`service_manage`
+Whether or not the MongoDB service resource should be part of the catalog.
+Default: true
+
 ####Class: mongodb::mongos
 class. This class should only be used if you want to implement sharding within
 your mongodb deployment.
@@ -441,6 +454,10 @@ Path to the config template if the default doesn't match one needs.
 
 #####`configdb`
 Array of the config servers IP addresses the mongos should connect to.
+
+#####`service_manage`
+Whether or not the MongoDB sharding service resource should be part of the catalog.
+Default: true
 
 #####`service_name`
 This setting can be used to override the default Mongos service name. If not

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -2,27 +2,29 @@
 # details.
 
 class mongodb::globals (
-  $server_package_name  = undef,
-  $client_package_name  = undef,
-  $mongos_package_name  = undef,
+  $server_package_name   = undef,
+  $client_package_name   = undef,
+  $mongos_package_name   = undef,
 
-  $service_enable       = undef,
-  $service_ensure       = undef,
-  $service_name         = undef,
-  $mongos_service_name  = undef,
-  $service_provider     = undef,
-  $service_status       = undef,
+  $mongod_service_manage = undef,
+  $service_enable        = undef,
+  $service_ensure        = undef,
+  $service_name          = undef,
+  $mongos_service_manage = undef,
+  $mongos_service_name   = undef,
+  $service_provider      = undef,
+  $service_status        = undef,
 
-  $user                 = undef,
-  $group                = undef,
-  $ipv6                 = undef,
-  $bind_ip              = undef,
+  $user                  = undef,
+  $group                 = undef,
+  $ipv6                  = undef,
+  $bind_ip               = undef,
 
-  $version              = undef,
+  $version               = undef,
 
-  $manage_package_repo  = undef,
+  $manage_package_repo   = undef,
 
-  $use_enterprise_repo  = undef,
+  $use_enterprise_repo   = undef,
 ) {
 
   # Setup of the repo only makes sense globally, so we are doing it here.

--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -4,6 +4,7 @@ class mongodb::mongos (
   $config           = $mongodb::params::mongos_config,
   $config_content   = undef,
   $configdb         = $mongodb::params::mongos_configdb,
+  $service_manage   = $mongodb::params::mongos_service_manage,
   $service_provider = $mongodb::params::mongos_service_provider,
   $service_name     = $mongodb::params::mongos_service_name,
   $service_enable   = $mongodb::params::mongos_service_enable,

--- a/manifests/mongos/service.pp
+++ b/manifests/mongos/service.pp
@@ -1,5 +1,6 @@
 # PRIVATE CLASS: do not call directly
 class mongodb::mongos::service (
+  $service_manage   = $mongodb::mongos::service_manage,
   $service_name     = $mongodb::mongos::service_name,
   $service_enable   = $mongodb::mongos::service_enable,
   $service_ensure   = $mongodb::mongos::service_ensure,
@@ -48,21 +49,23 @@ class mongodb::mongos::service (
     before  => Service['mongos'],
   }
 
-  service { 'mongos':
-    ensure    => $service_ensure_real,
-    name      => $service_name,
-    enable    => $service_enable,
-    provider  => $service_provider,
-    hasstatus => true,
-    status    => $service_status,
-  }
+  if $service_manage {
+    service { 'mongos':
+      ensure    => $service_ensure_real,
+      name      => $service_name,
+      enable    => $service_enable,
+      provider  => $service_provider,
+      hasstatus => true,
+      status    => $service_status,
+    }
 
-  if $service_ensure_real {
-    mongodb_conn_validator { 'mongos':
-      server  => $bind_ip_real,
-      port    => $port_real,
-      timeout => '240',
-      require => Service['mongos'],
+    if $service_ensure_real {
+      mongodb_conn_validator { 'mongos':
+        server  => $bind_ip_real,
+        port    => $port_real,
+        timeout => '240',
+        require => Service['mongos'],
+      }
     }
   }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,10 +3,12 @@ class mongodb::params inherits mongodb::globals {
   $ensure                = true
   $mongos_ensure         = true
   $ipv6                  = undef
+  $service_manage        = pick($mongodb::globals::mongod_service_manage, true)
   $service_enable        = pick($mongodb::globals::service_enable, true)
   $service_ensure        = pick($mongodb::globals::service_ensure, 'running')
   $service_status        = $mongodb::globals::service_status
 
+  $mongos_service_manage = pick($mongodb::globals::mongos_service_manage, true)
   $mongos_service_enable = pick($mongodb::globals::mongos_service_enable, true)
   $mongos_service_ensure = pick($mongodb::globals::mongos_service_ensure, 'running')
   $mongos_service_status = $mongodb::globals::mongos_service_status

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -9,6 +9,7 @@ class mongodb::server (
   $dbpath           = $mongodb::params::dbpath,
   $pidfilepath      = $mongodb::params::pidfilepath,
 
+  $service_manage   = $mongodb::params::service_manage,
   $service_provider = $mongodb::params::service_provider,
   $service_name     = $mongodb::params::service_name,
   $service_enable   = $mongodb::params::service_enable,

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -1,6 +1,7 @@
 # PRIVATE CLASS: do not call directly
 class mongodb::server::service {
   $ensure           = $mongodb::server::service_ensure
+  $service_manage   = $mongodb::server::service_manage
   $service_enable   = $mongodb::server::service_enable
   $service_name     = $mongodb::server::service_name
   $service_provider = $mongodb::server::service_provider
@@ -35,21 +36,24 @@ class mongodb::server::service {
     default => true
   }
 
-  service { 'mongodb':
-    ensure    => $service_ensure,
-    name      => $service_name,
-    enable    => $service_enable,
-    provider  => $service_provider,
-    hasstatus => true,
-    status    => $service_status,
-  }
+  if $service_manage {
+    service { 'mongodb':
+      ensure    => $service_ensure,
+      name      => $service_name,
+      enable    => $service_enable,
+      provider  => $service_provider,
+      hasstatus => true,
+      status    => $service_status,
+    }
 
-  if $service_ensure {
-    mongodb_conn_validator { 'mongodb':
-      server  => $bind_ip_real,
-      port    => $port_real,
-      timeout => '240',
-      require => Service['mongodb'],
+    if $service_ensure {
+      mongodb_conn_validator { 'mongodb':
+        server  => $bind_ip_real,
+        port    => $port_real,
+        timeout => '240',
+        require => Service['mongodb'],
+      }
     }
   }
+
 }

--- a/spec/classes/mongos_service_spec.rb
+++ b/spec/classes/mongos_service_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'mongodb::mongos::service', :type => :class do
 
-  context 'on Debian' do
+  context 'on Debian with service_manage set to true' do
     let :facts do
       {
         :osfamily        => 'Debian',
@@ -23,9 +23,31 @@ describe 'mongodb::mongos::service', :type => :class do
     describe 'configure the mongos service' do
       it { should contain_service('mongos') }
     end
+
   end
 
-  context 'on RedHat' do
+  context 'on Debian with service_manage set to false' do
+    let :facts do
+      {
+        :osfamily        => 'Debian',
+        :operatingsystem => 'Debian',
+      }
+    end
+
+    let :pre_condition do
+      "class { 'mongodb::mongos':
+         configdb => ['127.0.0.1:27019'],
+         service_manage => false,
+       }"
+    end
+
+    describe 'configure the mongos service' do
+      it { should_not contain_service('mongos') }
+    end
+
+  end
+
+  context 'on RedHat with service_manage set to true' do
     let :facts do
       {
         :osfamily        => 'RedHat',
@@ -50,6 +72,28 @@ describe 'mongodb::mongos::service', :type => :class do
     describe 'configure the mongos service' do
       it { should contain_service('mongos') }
     end
+
+  end
+
+  context 'on RedHat with service_manage set to false' do
+    let :facts do
+      {
+        :osfamily        => 'RedHat',
+        :operatingsystem => 'RedHat',
+      }
+    end
+
+    let :pre_condition do
+      "class { 'mongodb::mongos':
+         configdb => ['127.0.0.1:27019'],
+         service_manage => false,
+       }"
+    end
+
+    describe 'configure the mongos service' do
+      it { should_not contain_service('mongos') }
+    end
+
   end
 
 


### PR DESCRIPTION
Allow a deployer to not have the service resource from the catalog.

This feature is useful when one manages the service through another
program, like pacemaker.

With a pacemaker setup, a user ensure a service is stopped, pacemaker is
in charge of starting it. At a subsequent run, puppet will make sure the
service is stopped again. To avoid that, this feature offer an option to
the user to not manage the resource at all.