### PR TITLE
Typo in $config in params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,7 +75,7 @@ class mongodb::params inherits mongodb::globals {
         $client_package_name = pick($::mongodb::globals::client_package_name, 'mongodb')
         $mongos_package_name = pick($::mongodb::globals::mongos_package_name, 'mongodb-server')
         $service_name        = pick($::mongodb::globals::service_name, 'mongod')
-        $config              = '/etc/mongodb.conf'
+        $config              = '/etc/mongod.conf'
         $mongos_config       = '/etc/mongodb-shard.conf'
         $dbpath              = '/var/lib/mongodb'
         $logpath             = '/var/log/mongodb/mongodb.log'


### PR DESCRIPTION
Seems to be a typo here, the config file for mongodb is located on /etc/mongod.conf, not /etc/mongodb.conf:
#rpm -qf /etc/mongod.conf 
mongodb-server-2.6.9-1.el7.x86_64
#rpm -qf /etc/mongodb.conf 
file /etc/mongodb.conf is not owned by any packag