### PR TITLE
Make mongodb_conn_validator namevar the URI to check

### DIFF
--- a/lib/puppet/provider/mongodb_conn_validator/tcp_port.rb
+++ b/lib/puppet/provider/mongodb_conn_validator/tcp_port.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:mongodb_conn_validator).provide(:tcp_port) do
 
   # @api private
   def validator
-    @validator ||= Puppet::Util::MongodbValidator.new(resource[:server], resource[:port])
+    @validator ||= Puppet::Util::MongodbValidator.new(resource[:name], resource[:server], resource[:port])
   end
 
 end

--- a/lib/puppet/type/mongodb_conn_validator.rb
+++ b/lib/puppet/type/mongodb_conn_validator.rb
@@ -12,11 +12,12 @@ Puppet::Type.newtype(:mongodb_conn_validator) do
   end
 
   newparam(:name, :namevar => true) do
-    desc 'An arbitrary name used as the identity of the resource.'
+    desc 'An arbitrary name used as the identity of the resource. It can also be the connection string to test (ie. 127.0.0.1:27017)'
   end
 
   newparam(:server) do
     desc 'An array containing DNS names or IP addresses of the server where mongodb should be running.'
+    defaultto '127.0.0.1'
     munge do |value|
       Array(value).first
     end
@@ -24,6 +25,7 @@ Puppet::Type.newtype(:mongodb_conn_validator) do
 
   newparam(:port) do
     desc 'The port that the mongodb server should be listening on.'
+    defaultto '27017'
   end
 
   newparam(:timeout) do


### PR DESCRIPTION
Currently one needs to pass server and port parameters for each node
s/he wants to test if mongodb is up and running. Admiting we have an
array of nodes there is no easy way to check all of them.

By allowing the name of the resource as the connection to test, this
scenario can be easily dealt with.

```
$array_of_mongo_nodes = ['ip1:27017', 'ip2:27017', '[::1]:27017']
mongodb_conn_validator { $array_of_mongo_nodes : }
```