### PR TITLE
Set config path based on release on RH platforms

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -75,19 +75,21 @@ class mongodb::params inherits mongodb::globals {
         $client_package_name = pick($::mongodb::globals::client_package_name, 'mongodb')
         $mongos_package_name = pick($::mongodb::globals::mongos_package_name, 'mongodb-server')
         $service_name        = pick($::mongodb::globals::service_name, 'mongod')
-        $config              = '/etc/mongodb.conf'
-        $mongos_config       = '/etc/mongodb-shard.conf'
         $dbpath              = '/var/lib/mongodb'
         $logpath             = '/var/log/mongodb/mongodb.log'
         $bind_ip             = pick($::mongodb::globals::bind_ip, ['127.0.0.1'])
         if ($::operatingsystem == 'fedora' and versioncmp($::operatingsystemrelease, '22') >= 0 or
             $::operatingsystem != 'fedora' and versioncmp($::operatingsystemrelease, '7.0') >= 0) {
+          $config                  = '/etc/mongod.conf'
+          $mongos_config           = '/etc/mongos.conf'
           $pidfilepath             = '/var/run/mongodb/mongod.pid'
           $mongos_pidfilepath      = '/var/run/mongodb/mongos.pid'
           $mongos_unixsocketprefix = '/var/run/mongodb'
           $mongos_logpath          = '/var/log/mongodb/mongodb-shard.log'
           $mongos_fork             = true
         } else {
+          $config                  = '/etc/mongodb.conf'
+          $mongos_config           = '/etc/mongodb-shard.conf'
           $pidfilepath             = '/var/run/mongodb/mongodb.pid'
           $mongos_pidfilepath      = undef
           $mongos_unixsocketprefix = undef


### PR DESCRIPTION
Set mongod.conf / mongos.conf on:

* EPEL 7+

* Fedora 22+

Set mongodb.conf / mongodb-shard.conf for older releases.