### PR TITLE
Fix mongodb_user's username => name

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ The maximum amount of two second tries to wait MongoDB startup. Default: 10
 
 ```puppet
 mongodb_user { testuser:
-  username      => 'testuser',
+  name          => 'testuser',
   ensure        => present,
   password_hash => mongodb_password('testuser', 'p@ssw0rd'),
   database      => testdb,


### PR DESCRIPTION
`username` returns "Invalid parameter username". The parameter should be `name` instead. Plus, the test also expects that: https://github.com/puppetlabs/puppetlabs-mongodb/blob/master/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb