### PR TITLE
remove another JavaScript object from the output of db.isMaster() aft…

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -252,6 +252,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, :parent => Puppet::Provider:
     # Dirty hack to remove JavaScript objects
     output.gsub!(/ISODate\((.+?)\)/, '\1 ')
     output.gsub!(/Timestamp\((.+?)\)/, '[\1]')
+    output.gsub!(/ObjectId\((.+?)\)/, '\1')
 
     #Hack to avoid non-json empty sets
     output = "{}" if output == "null\n"


### PR DESCRIPTION
…er https://jira.mongodb.org/browse/SERVER-13542

In mongo 2.6.10 the output of db.isMaster() now has another JavaScript object. The output looks like this:
{
  "setName" : "rstest",
  "setVersion" : 1, 
  "ismaster" : true, 
  "secondary" : false, 
  "hosts" : [ "mongohost1:27017" ],
  "primary" : "mongohost1:27017", 
  "me" :  "mongohost1:27017", 
  "electionId" : ObjectId("5577f0859cdb548fdd637f19"),
  "maxBsonObjectSize" : 16777216,
  "maxMessageSizeBytes" : 48000000,
  "maxWriteBatchSize" : 1000,
  "localTime" : "2015-06-10T08:53:30.141Z" ,
  "maxWireVersion" : 2,
  "minWireVersion" : 0,
  "ok" : 1
} 

