### PR TITLE
Update apt dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,6 +613,10 @@ For a full list of tested operating systems please have a look at the [.nodeset.
 
 This module should support `service_ensure` separate from the `ensure` value on `Class[mongodb::server]` but it does not yet.
 
+### Apt module support
+
+While this module supports both 1.x and 2.x versions of the puppetlabs-apt module, it does not support puppetlabs-apt 2.0.0 or 2.0.1.
+
 ## Development
 
 Puppet Labs modules on the Puppet Forge are open projects, and community

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
     }
   ],
   "dependencies": [
-    {"name":"puppetlabs/apt","version_requirement":">= 1.0.0 <2.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">= 1.0.0 <3.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 2.2.0 <5.0.0"}
   ]
 }


### PR DESCRIPTION
Once puppetlabs-apt 2.1.0 is released (2015-06-16) the mongodb module
will be compatible with apt 1.x (>= 1.8.0) and 2.x (>= 2.1.0). This will
not work with puppetlabs-apt 2.0.x.