### PR TITLE
Make distinguish between repo and package mgmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,19 @@ class {'::mongodb::server': }->
 class {'::mongodb::client': }
 ```
 
+Having a local copy of MongoDB repository (that is managed by your private modules)
+you can still enjoy the charms of `mongodb::params` that manage packages.
+To disable managing of repository, but still enable managing packages:
+
+```puppet
+class {'::mongodb::globals':
+  manage_package_repo => false,
+  manage_package      => true,
+}->
+class {'::mongodb::server': }->
+class {'::mongodb::client': }
+```
+
 ## Usage
 
 Most of the interaction for the server is done via `mongodb::server`. For

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -23,6 +23,7 @@ class mongodb::globals (
   $version               = undef,
 
   $manage_package_repo   = undef,
+  $manage_package        = undef,
 
   $use_enterprise_repo   = undef,
 ) {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -16,11 +16,13 @@ class mongodb::params inherits mongodb::globals {
   $mongos_configdb       = '127.0.0.1:27019'
   $mongos_restart        = true
 
+  $manage_package        = pick($mongodb::globals::manage_package, $mongodb::globals::manage_package_repo, false)
+
   # Amazon Linux's OS Family is 'Linux', operating system 'Amazon'.
   case $::osfamily {
     'RedHat', 'Linux': {
 
-      if $mongodb::globals::manage_package_repo {
+      if $manage_package {
         $user        = pick($::mongodb::globals::user, 'mongod')
         $group       = pick($::mongodb::globals::group, 'mongod')
         if ($::mongodb::globals::version == undef) {
@@ -105,7 +107,7 @@ class mongodb::params inherits mongodb::globals {
       }
     }
     'Debian': {
-      if $::mongodb::globals::manage_package_repo {
+      if $manage_package {
         $user  = pick($::mongodb::globals::user, 'mongodb')
         $group = pick($::mongodb::globals::group, 'mongodb')
         if ($::mongodb::globals::version == undef) {


### PR DESCRIPTION
We have local copy of repository, but we still would like to use package mgmt,
because of that we would like to make distinguish between repo and package mgmt.

I tried to make it back compatible, so now you can just do (hiera style):
```
mongodb::globals::manage_package: true
mongodb::globals::manage_package_repo: false
```
which means that that `mongodb::repo` will not be enabled,
but use can still use `mongodb::params` which do magic of version handling.