### PR TITLE
Added specific service provider for Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -184,6 +184,16 @@ class mongodb::params inherits mongodb::globals {
   }
 
   case $::operatingsystem {
+    'Debian': {
+      case $::operatingsystemmajrelease {
+        '8': {
+          $service_provider = pick($service_provider, 'systemd')
+        }
+        default: {
+          $service_provider = pick($service_provider, 'debian')
+        }
+      }
+    }
     'Ubuntu': {
       $service_provider = pick($service_provider, 'upstart')
     }
@@ -191,5 +201,4 @@ class mongodb::params inherits mongodb::globals {
       $service_provider = undef
     }
   }
-
 }


### PR DESCRIPTION
As restarting service with `/etc/init.d/mongodb` on Jessie is fairly often failing due to redirection into systemd pure systemd should be used to solve it (in most cases)