### PR TITLE
globals: fix, add pidfilepath to globals when used in params

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -30,6 +30,8 @@ class mongodb::globals (
 
   $repo_location         = undef,
   $use_enterprise_repo   = undef,
+
+  $pidfilepath           = undef,
 ) {
 
   # Setup of the repo only makes sense globally, so we are doing it here.


### PR DESCRIPTION
Hi,

a very small fix - $pidfilepath might be set using globals but there is no way to specify it.

Thanks
Mathias