### PR TITLE
Improvements for replica set and authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor/
 spec/fixtures/
 .vagrant/
 .bundle/
+.bundled_gems/
 coverage/
 .idea/
 *.iml

--- a/README.md
+++ b/README.md
@@ -398,6 +398,16 @@ Use this setting to enable shard server mode for mongod.
 Use this setting to configure replication with replica sets. Specify a replica
 set name as an argument to this set. All hosts must have the same set name.
 
+#####`replica_sets`
+Sets of nodes for replica.
+
+```puppet
+class mongodb::server {
+  replet       => 'rsmain',
+  replica_sets => { 'rsmain' => { ensure  => present, members => ['host1:27017', 'host2:27017', 'host3:27017'] } }
+}
+```
+
 #####`rest`
 Set to true to enable a simple REST interface. Default: false
 
@@ -527,6 +537,23 @@ If not specified, the module will use whatever service name is the default for y
 #####`restart`
 Specifies whether the service should be restarted on config changes. Default: 'true'
 
+#####`create_admin`
+Allows to create admin user for admin database.
+Redefine these parameters if needed:
+
+#####`admin_username`
+Administrator user name
+
+#####`admin_password`
+Administrator user password
+
+#####`admin_roles`
+Administrator user roles
+
+#####`create_mongo_rc`
+Store admin credentials in mongorc.js file. Uses with `create_admin` parameter
+
+
 ### Definitions
 
 #### Definition: mongodb:db
@@ -564,6 +591,9 @@ The maximum amount of two second tries to wait MongoDB startup. Default: 10
 
 #### Provider: mongodb_user
 'mongodb_user' can be used to create and manage users within MongoDB database.
+
+*Note:* if replica set is enabled, replica initialization has to come before
+any user operations.
 
 ```puppet
 mongodb_user { testuser:

--- a/lib/puppet/provider/mongodb_database/mongodb.rb
+++ b/lib/puppet/provider/mongodb_database/mongodb.rb
@@ -25,12 +25,24 @@ Puppet::Type.type(:mongodb_database).provide(:mongodb, :parent => Puppet::Provid
     end
   end
 
+  def db_ismaster
+    self.class.db_ismaster
+  end
+
   def create
-    mongo_eval('db.dummyData.insert({"created_by_puppet": 1})', @resource[:name])
+    if db_ismaster
+      mongo_eval('db.dummyData.insert({"created_by_puppet": 1})', @resource[:name])
+    else
+      Puppet.warning 'Database creation is available only from master host'
+    end
   end
 
   def destroy
-    mongo_eval('db.dropDatabase()', @resource[:name])
+    if db_ismaster
+      mongo_eval('db.dropDatabase()', @resource[:name])
+    else
+      Puppet.warning 'Database removal is available only from master host'
+    end
   end
 
   def exists?

--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -8,35 +8,40 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
   def self.instances
     require 'json'
 
-    if mongo_24?
-      dbs = JSON.parse mongo_eval('printjson(db.getMongo().getDBs()["databases"].map(function(db){return db["name"]}))') || 'admin'
+    if db_ismaster
+      if mongo_24?
+        dbs = JSON.parse mongo_eval('printjson(db.getMongo().getDBs()["databases"].map(function(db){return db["name"]}))') || 'admin'
 
-      allusers = []
+        allusers = []
 
-      dbs.each do |db|
-        users = JSON.parse mongo_eval('printjson(db.system.users.find().toArray())', db)
+        dbs.each do |db|
+          users = JSON.parse mongo_eval('printjson(db.system.users.find().toArray())', db)
 
-        allusers += users.collect do |user|
+          allusers += users.collect do |user|
+              new(:name          => user['_id'],
+                  :ensure        => :present,
+                  :username      => user['user'],
+                  :database      => db,
+                  :roles         => user['roles'].sort,
+                  :password_hash => user['pwd'])
+          end
+        end
+        return allusers
+      else
+        users = JSON.parse mongo_eval('printjson(db.system.users.find().toArray())')
+
+        users.collect do |user|
             new(:name          => user['_id'],
                 :ensure        => :present,
                 :username      => user['user'],
-                :database      => db,
-                :roles         => user['roles'].sort,
-                :password_hash => user['pwd'])
+                :database      => user['db'],
+                :roles         => from_roles(user['roles'], user['db']),
+                :password_hash => user['credentials']['MONGODB-CR'])
         end
       end
-      return allusers
     else
-      users = JSON.parse mongo_eval('printjson(db.system.users.find().toArray())')
-
-      users.collect do |user|
-          new(:name          => user['_id'],
-              :ensure        => :present,
-              :username      => user['user'],
-              :database      => user['db'],
-              :roles         => from_roles(user['roles'], user['db']),
-              :password_hash => user['credentials']['MONGODB-CR'])
-      end
+      Puppet.warning 'User info is available only from master host'
+      return []
     end
   end
 
@@ -52,46 +57,56 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
 
   mk_resource_methods
 
+  def db_ismaster
+    self.class.db_ismaster
+  end
+
   def create
+    if db_ismaster
+      if mongo_24?
+        user = {
+          :user => @resource[:username],
+          :pwd => @resource[:password_hash],
+          :roles => @resource[:roles]
+        }
 
+        mongo_eval("db.addUser(#{user.to_json})", @resource[:database])
+      else
+        cmd_json=<<-EOS.gsub(/^\s*/, '').gsub(/$\n/, '')
+        {
+          "createUser": "#{@resource[:username]}",
+          "pwd": "#{@resource[:password_hash]}",
+          "customData": {"createdBy": "Puppet Mongodb_user['#{@resource[:name]}']"},
+          "roles": #{@resource[:roles].to_json},
+          "digestPassword": false
+        }
+        EOS
 
-    if mongo_24?
-      user = {
-        :user => @resource[:username],
-        :pwd => @resource[:password_hash],
-        :roles => @resource[:roles]
-      }
+        mongo_eval("db.runCommand(#{cmd_json})", @resource[:database])
+      end
 
-      mongo_eval("db.addUser(#{user.to_json})", @resource[:database])
+      @property_hash[:ensure] = :present
+      @property_hash[:username] = @resource[:username]
+      @property_hash[:database] = @resource[:database]
+      @property_hash[:password_hash] = ''
+      @property_hash[:rolse] = @resource[:roles]
+
+      exists? ? (return true) : (return false)
     else
-      cmd_json=<<-EOS.gsub(/^\s*/, '').gsub(/$\n/, '')
-      {
-        "createUser": "#{@resource[:username]}",
-        "pwd": "#{@resource[:password_hash]}",
-        "customData": {"createdBy": "Puppet Mongodb_user['#{@resource[:name]}']"},
-        "roles": #{@resource[:roles].to_json},
-        "digestPassword": false
-      }
-      EOS
-
-      mongo_eval("db.runCommand(#{cmd_json})", @resource[:database])
+      Puppet.warning 'User creation is available only from master host'
     end
-
-    @property_hash[:ensure] = :present
-    @property_hash[:username] = @resource[:username]
-    @property_hash[:database] = @resource[:database]
-    @property_hash[:password_hash] = ''
-    @property_hash[:rolse] = @resource[:roles]
-
-    exists? ? (return true) : (return false)
   end
 
 
   def destroy
-    if mongo_24?
-      mongo_eval("db.removeUser('#{@resource[:username]}')")
+    if db_ismaster
+      if mongo_24?
+        mongo_eval("db.removeUser('#{@resource[:username]}')")
+      else
+        mongo_eval("db.dropUser('#{@resource[:username]}')")
+      end
     else
-      mongo_eval("db.dropUser('#{@resource[:username]}')")
+      Puppet.warning 'User removal is available only from master host'
     end
   end
 
@@ -100,30 +115,37 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
   end
 
   def password_hash=(value)
-    cmd_json=<<-EOS.gsub(/^\s*/, '').gsub(/$\n/, '')
-    {
-        "updateUser": "#{@resource[:username]}",
-        "pwd": "#{@resource[:password_hash]}",
-        "digestPassword": false
-    }
-    EOS
-
-    mongo_eval("db.runCommand(#{cmd_json})", @resource[:database])
+    if db_ismaster
+      cmd_json=<<-EOS.gsub(/^\s*/, '').gsub(/$\n/, '')
+      {
+          "updateUser": "#{@resource[:username]}",
+          "pwd": "#{@resource[:password_hash]}",
+          "digestPassword": false
+      }
+      EOS
+      mongo_eval("db.runCommand(#{cmd_json})", @resource[:database])
+    else
+      Puppet.warning 'User password operations are available only from master host'
+    end
   end
 
   def roles=(roles)
-    if mongo_24?
-      mongo_eval("db.system.users.update({user:'#{@resource[:username]}'}, { $set: {roles: #{@resource[:roles].to_json}}})")
-    else
-      grant = roles-@resource[:roles]
-      if grant.length > 0
-        mongo_eval("db.getSiblingDB('#{@resource[:database]}').grantRolesToUser('#{@resource[:username]}', #{grant. to_json})")
-      end
+    if db_ismaster
+      if mongo_24?
+        mongo_eval("db.system.users.update({user:'#{@resource[:username]}'}, { $set: {roles: #{@resource[:roles].to_json}}})")
+      else
+        grant = roles-@resource[:roles]
+        if grant.length > 0
+          mongo_eval("db.getSiblingDB('#{@resource[:database]}').grantRolesToUser('#{@resource[:username]}', #{grant. to_json})")
+        end
 
-      revoke = @resource[:roles]-roles
-      if revoke.length > 0
-        mongo_eval("db.getSiblingDB('#{@resource[:database]}').revokeRolesFromUser('#{@resource[:username]}', #{revoke.to_json})")
+        revoke = @resource[:roles]-roles
+        if revoke.length > 0
+          mongo_eval("db.getSiblingDB('#{@resource[:database]}').revokeRolesFromUser('#{@resource[:username]}', #{revoke.to_json})")
+        end
       end
+    else
+      Puppet.warning 'User roles operations are available only from master host'
     end
   end
 

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -21,7 +21,6 @@ define mongodb::db (
   mongodb_database { $name:
     ensure  => present,
     tries   => $tries,
-    require => Class['mongodb::server'],
   }
 
   if $password_hash {

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -19,8 +19,8 @@ define mongodb::db (
 ) {
 
   mongodb_database { $name:
-    ensure  => present,
-    tries   => $tries,
+    ensure => present,
+    tries  => $tries,
   }
 
   if $password_hash {

--- a/manifests/replset.pp
+++ b/manifests/replset.pp
@@ -1,4 +1,5 @@
 # Wrapper class useful for hiera based deployments
+# Internal class, do not call directly
 
 class mongodb::replset(
   $sets = undef

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -74,12 +74,12 @@ class mongodb::server (
   # Do not redefine 'admin_roles' parameter
   # if you want to get full access for admin user
   $admin_roles     = ['userAdmin', 'readWrite', 'dbAdmin',
-                       'dbAdminAnyDatabase', 'readAnyDatabase',
-                       'readWriteAnyDatabase', 'userAdminAnyDatabase',
-                       'clusterAdmin', 'clusterManager', 'clusterMonitor',
-                       'hostManager', 'root', 'restore'],
+                      'dbAdminAnyDatabase', 'readAnyDatabase',
+                      'readWriteAnyDatabase', 'userAdminAnyDatabase',
+                      'clusterAdmin', 'clusterManager', 'clusterMonitor',
+                      'hostManager', 'root', 'restore'],
 
-  # E.g. { 'relica_name' = { auth_enabled => true, members => ['10.0.0.1', '10.0.0.2'] } }
+  # E.g. { 'relica_name' = { members => ['10.0.0.1', '10.0.0.2'] } }
   $replica_sets   = undef,
 
   # Deprecated parameters
@@ -106,7 +106,7 @@ class mongodb::server (
         group   => 'root',
         mode    => '0644',
         content => template('mongodb/mongorc.js.erb'),
-        path    => "/root/.mongorc.js",
+        path    => '/root/.mongorc.js',
         before  => Anchor['mongodb::server::start'],
       }
     }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -67,6 +67,21 @@ class mongodb::server (
   $restart         = $mongodb::params::restart,
   $storage_engine  = undef,
 
+  $create_admin    = true,
+  $create_mongo_rc = true,
+  $admin_username  = 'admin',
+  $admin_password  = 'changeme',
+  # Do not redefine 'admin_roles' parameter
+  # if you want to get full access for admin user
+  $admin_roles     = ['userAdmin', 'readWrite', 'dbAdmin',
+                       'dbAdminAnyDatabase', 'readAnyDatabase',
+                       'readWriteAnyDatabase', 'userAdminAnyDatabase',
+                       'clusterAdmin', 'clusterManager', 'clusterMonitor',
+                       'hostManager', 'root', 'restore'],
+
+  # E.g. { 'relica_name' = { auth_enabled => true, members => ['10.0.0.1', '10.0.0.2'] } }
+  $replica_sets   = undef,
+
   # Deprecated parameters
   $master          = undef,
   $slave           = undef,
@@ -77,6 +92,47 @@ class mongodb::server (
 
   if $ssl {
     validate_string($ssl_key, $ssl_ca)
+  }
+
+  if $admin_password {
+    validate_string($admin_password)
+  }
+
+  if $create_admin {
+    if $create_mongo_rc {
+      file { 'mongodb_rc':
+        ensure  => present,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0644',
+        content => template('mongodb/mongorc.js.erb'),
+        path    => "/root/.mongorc.js",
+        before  => Anchor['mongodb::server::start'],
+      }
+    }
+
+    mongodb::db { 'admin':
+      user     => $admin_username,
+      password => $admin_password,
+      roles    => $admin_roles,
+    }
+    Anchor['mongodb::server::end'] -> Mongodb::Db['admin']
+  }
+
+  if $replset {
+    if $replica_sets {
+      validate_hash($replica_sets)
+
+      class { 'mongodb::replset':
+        sets => $replica_sets,
+      }
+      Anchor['mongodb::server::end'] -> Class['mongodb::replset']
+      if $create_admin {
+        Class['mongodb::replset'] -> Mongodb::Db['admin']
+      }
+    } else {
+      fail('You must set replica set members if replica is enabled')
+    }
   }
 
   if ($ensure == 'present' or $ensure == true) {

--- a/spec/defines/db_spec.rb
+++ b/spec/defines/db_spec.rb
@@ -9,11 +9,6 @@ describe 'mongodb::db', :type => :define do
     }
   }
 
-  it 'should contain mongodb_database with mongodb::server requirement' do
-    is_expected.to contain_mongodb_database('testdb')\
-      .with_require('Class[Mongodb::Server]')
-  end
-
   it 'should contain mongodb_user with mongodb_database requirement' do
     is_expected.to contain_mongodb_user('User testuser on db testdb').with({
       'username' => 'testuser',

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -24,8 +24,9 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
   let(:provider) { resource.provider }
 
   before :each do
-     provider.class.stubs(:mongo_eval).with('printjson(db.system.users.find().toArray())').returns(raw_users)
-     provider.class.stubs(:mongo_version).returns('2.6.x')
+    provider.class.stubs(:mongo_eval).with('printjson(db.system.users.find().toArray())').returns(raw_users)
+    provider.class.stubs(:mongo_version).returns('2.6.x')
+    allow(provider.class).to receive(:db_ismaster).and_return(true)
   end
 
   let(:instance) { provider.class.instances.first }
@@ -34,6 +35,13 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
     it 'returns an array of users' do
       usernames = provider.class.instances.collect {|x| x.username }
       expect(parsed_users).to match_array(usernames)
+    end
+  end
+
+  describe 'empty self.instances from slave' do
+    it 'doesn`t retrun array of users' do
+      allow(provider.class).to receive(:db_ismaster).and_return(false)
+      expect(provider.class.instances).to match_array([])
     end
   end
 

--- a/templates/mongorc.js.erb
+++ b/templates/mongorc.js.erb
@@ -1,0 +1,26 @@
+function authRequired() {
+  try {
+    if (db.serverCmdLineOpts().code == 13) {
+      return true;
+    }
+    return false;
+  }
+  catch (err) {
+    return false;
+  }
+}
+
+if (authRequired()) {
+  try {
+<% if @replset -%>
+    rs.slaveOk()
+<% end -%>
+    var prev_db = db
+    db = db.getSiblingDB('admin')
+    db.auth('<%= @admin_username %>', '<%= @admin_password %>')
+    db = db.getSiblingDB(prev_db)
+  }
+  catch (err) {
+    return;
+  }
+}


### PR DESCRIPTION
This patchset contains following key changes:

* Add ability to create admin user
* Doc: all users should be created
  only after replica set initialization if it's enabled
* Add ability to create mongorc file with admin credentials
(thanks Gavin Williams for this good idea)
* Use mongorc file for replica set commands
* Prevent users from errors when puppet can try to work with
Mongo users, databases and roles from slave nodes
(additional check was added for each method)
* Add and fix tests according these changes