### PR TITLE
added yum proxy options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+### Summary
+- support setting a proxy for yum repositories with or without user/password authentication
+
 ## 2015-06-22 - Release 0.11.0
 ### Summary
 

--- a/README.md
+++ b/README.md
@@ -232,6 +232,15 @@ the module will use the default for your OS distro.
 This setting can be used to override the default MongoDB repository location.
 If not specified, the module will use the default repository for your OS distro.
 
+#####`repo_proxy`
+This will allow you to set a proxy for your repository in case you are behind a corporate firewall. Currently this is only supported with yum repositories
+
+#####`proxy_username`
+This sets the username for the proxyserver, should authentication be required
+
+#####`proxy_password`
+This sets the password for the proxyserver, should authentication be required
+
 ####Class: mongodb::server
 
 Most of the parameters manipulate the mongod.conf file.

--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -27,6 +27,9 @@ class mongodb::globals (
 
   $manage_package_repo   = undef,
   $manage_package        = undef,
+  $repo_proxy            = undef,
+  $proxy_username        = undef,
+  $proxy_password        = undef,
 
   $repo_location         = undef,
   $use_enterprise_repo   = undef,
@@ -39,6 +42,7 @@ class mongodb::globals (
     class { '::mongodb::repo':
       ensure        => present,
       repo_location => $repo_location,
+      proxy         => $repo_proxy,
     }
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -1,8 +1,11 @@
 # PRIVATE CLASS: do not use directly
 class mongodb::repo (
-  $ensure        = $mongodb::params::ensure,
-  $version       = $mongodb::params::version,
-  $repo_location = undef,
+  $ensure         = $mongodb::params::ensure,
+  $version        = $mongodb::params::version,
+  $repo_location  = undef,
+  $proxy          = undef,
+  $proxy_username = undef,
+  $proxy_password = undef,
 ) inherits mongodb::params {
   case $::osfamily {
     'RedHat', 'Linux': {

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -5,10 +5,13 @@ class mongodb::repo::yum inherits mongodb::repo {
 
   if($::mongodb::repo::ensure == 'present' or $::mongodb::repo::ensure == true) {
     yumrepo { 'mongodb':
-      descr    => $::mongodb::repo::description,
-      baseurl  => $::mongodb::repo::location,
-      gpgcheck => '0',
-      enabled  => '1',
+      descr          => $::mongodb::repo::description,
+      baseurl        => $::mongodb::repo::location,
+      gpgcheck       => '0',
+      enabled        => '1',
+      proxy          => $::mongodb::repo::proxy,
+      proxy_username => $::mongodb::repo::proxy_username,
+      proxy_password => $::mongodb::repo::proxy_password,
     }
     Yumrepo['mongodb'] -> Package<|tag == 'mongodb'|>
   }

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -29,4 +29,30 @@ describe 'mongodb::repo', :type => :class do
     }
   end
 
+  context 'when yumrepo has a proxy set' do
+    let :facts do
+      {
+        :osfamily        => 'RedHat',
+        :operatingsystem => 'RedHat',
+      }
+    end
+    let :params do
+      {
+        :proxy => 'http://proxy-server:8080',
+        :proxy_username => 'proxyuser1',
+        :proxy_password => 'proxypassword1',
+      }
+    end
+    it {
+      is_expected.to contain_class('mongodb::repo::yum')
+    }
+    it do
+      should contain_yumrepo('mongodb').with({
+        'enabled' => '1',
+        'proxy' => 'http://proxy-server:8080',
+        'proxy_username' => 'proxyuser1',
+        'proxy_password' => 'proxypassword1',
+        })
+    end
+  end
 end


### PR DESCRIPTION
Just like with the postgresql modules there was no option to add a proxy for the yum repositories which may be necessary if you are sitting behind a corporate firewall. Please let me know if something is missing, is not right or needs to be changed.

Kind regards,
Alex