### PR TITLE
(MODULES-2636) Fix mongodb_user role management

### DIFF
--- a/lib/puppet/provider/mongodb_user/mongodb.rb
+++ b/lib/puppet/provider/mongodb_user/mongodb.rb
@@ -102,7 +102,7 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
         mongo_eval("db.dropUser('#{@resource[:username]}')")
       end
     else
-      Puppet.warning 'User removal is available only from master host'
+      mongo_eval("db.dropUser('#{@resource[:username]}')")
     end
   end
 
@@ -130,12 +130,12 @@ Puppet::Type.type(:mongodb_user).provide(:mongodb, :parent => Puppet::Provider::
       if mongo_24?
         mongo_eval("db.system.users.update({user:'#{@resource[:username]}'}, { $set: {roles: #{@resource[:roles].to_json}}})")
       else
-        grant = roles-@resource[:roles]
+        grant = roles-@property_hash[:roles]
         if grant.length > 0
           mongo_eval("db.getSiblingDB('#{@resource[:database]}').grantRolesToUser('#{@resource[:username]}', #{grant. to_json})")
         end
 
-        revoke = @resource[:roles]-roles
+        revoke = @property_hash[:roles]-roles
         if revoke.length > 0
           mongo_eval("db.getSiblingDB('#{@resource[:database]}').revokeRolesFromUser('#{@resource[:username]}', #{revoke.to_json})")
         end

--- a/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_user/mongodb_spec.rb
@@ -109,22 +109,27 @@ describe Puppet::Type.type(:mongodb_user).provider(:mongodb) do
 
   describe 'roles=' do
     it 'changes nothing' do
+      resource.provider.set(:name => 'new_user', :ensure => :present, :roles => ['role1','role2'])
       provider.expects(:mongo_eval).times(0)
       provider.roles=(['role1', 'role2'])
     end
 
     it 'grant a role' do
-      provider.expects(:mongo_eval).with("db.getSiblingDB('new_database').grantRolesToUser('new_user', [\"role3\"])")
+      resource.provider.set(:name => 'new_user', :ensure => :present, :roles => ['role1','role2'])
+      provider.expects(:mongo_eval).
+        with("db.getSiblingDB('new_database').grantRolesToUser('new_user', [\"role3\"])")
       provider.roles=(['role1', 'role2', 'role3'])
     end
 
     it 'revokes a role' do
+      resource.provider.set(:name => 'new_user', :ensure => :present, :roles => ['role1','role2'])
       provider.expects(:mongo_eval).
         with("db.getSiblingDB('new_database').revokeRolesFromUser('new_user', [\"role1\"])")
       provider.roles=(['role2'])
     end
 
     it 'exchanges a role' do
+      resource.provider.set(:name => 'new_user', :ensure => :present, :roles => ['role1','role2'])
       provider.expects(:mongo_eval).
         with("db.getSiblingDB('new_database').revokeRolesFromUser('new_user', [\"role1\"])")
       provider.expects(:mongo_eval).


### PR DESCRIPTION
Switch to comparing current roles value with @property_hash[:roles] value, and fix failing tests as a result.

