### PR TITLE
Mongodb::repo::apt: Fix deprication warnings from apt module

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -7,12 +7,12 @@ class mongodb::repo::apt inherits mongodb::repo {
 
   if($::mongodb::repo::ensure == 'present' or $::mongodb::repo::ensure == true) {
     apt::source { 'mongodb':
-      location    => $::mongodb::repo::location,
-      release     => 'dist',
-      repos       => '10gen',
-      key         => '492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10',
-      key_server  => 'hkp://keyserver.ubuntu.com:80',
-      include_src => false,
+      location => $::mongodb::repo::location,
+      release  => 'dist',
+      repos    => '10gen',
+      key      => '492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10',
+      server   => 'hkp://keyserver.ubuntu.com:80',
+      src      => false,
     }
 
     Apt::Source['mongodb']->Package<|tag == 'mongodb'|>


### PR DESCRIPTION
When using the [upstream apt module from puppetlabs](https://github.com/puppetlabs/puppetlabs-apt.git) I got these deprication warnings:
```puppet
==> v-tralsvr218: Warning: Scope(Apt::Source[mongodb]): $include_src is deprecated and will be removed in the next major release, please use $include => { 'src' => false } instead
==> v-tralsvr218: Warning: Scope(Apt::Source[mongodb]): $key_server is deprecated and will be removed in the next major release, please use $key => { 'server' => hkp://keyserver.ubuntu.com:80 } instead.
==> v-tralsvr218: Warning: Scope(Apt::Key[Add key: 492EAFE8CD016A07919F1D2B9ECBEC467F0CEB10 from Apt::Source mongodb]): $key_server is deprecated and will be removed in the next major release. Please use $server instead.
```
This commit updates the key => values in the mongodb::repos::apt class  to use the new ones.
Signed-off-by: bjanssens <bjanssens@inuits.eu>