### PR TITLE
Fix auth_enabled condition for mongo version >= 2.6

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -69,7 +69,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, :parent => Puppet::Provider:
   end
 
   def rs_initiate(conf, master)
-    if auth_enabled
+    if auth_enabled and auth_enabled != 'disable'
       return mongo_command("rs.initiate(#{conf})", initialize_host)
     else
       return mongo_command("rs.initiate(#{conf})", master)


### PR DESCRIPTION
Since mongo 2.6 in mongod.conf file, the auth parameter isn't a boolean but a string:
security.authorization: enabled/disable
