### PR TITLE
fix for javascript object in JSON

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -268,6 +268,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, :parent => Puppet::Provider:
     # Dirty hack to remove JavaScript objects
     output.gsub!(/ISODate\((.+?)\)/, '\1 ')
     output.gsub!(/Timestamp\((.+?)\)/, '[\1]')
+    output.gsub!(/ObjectId\(([^)]*)\)/, '\1')
 
     #Hack to avoid non-json empty sets
     output = "{}" if output == "null\n"


### PR DESCRIPTION
This issue was raised in a previous pull request #218 , and this issue was closed by @hunner.  However, as far as I can tell the fix was never actually merged (confirmed by @webzakimbo).  I've tested and this fix does solve the problem stated in the previous request, could we merge it in?  As far as I can tell replset doesn't work without this fix.