### PR TITLE
(MODULES-2983) Enable IPv6 in mongodb provider

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -80,7 +80,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     if mongorc_file
         cmd_ismaster = mongorc_file + cmd_ismaster
     end
-    out = mongo(['admin', '--quiet', '--host', get_conn_string, '--eval', cmd_ismaster])
+    out = mongo(['admin', '--quiet', '--ipv6', '--host', get_conn_string, '--eval', cmd_ismaster])
     out.gsub!(/ObjectId\(([^)]*)\)/, '\1')
     out.gsub!(/ISODate\((.+?)\)/, '\1 ')
     out.gsub!(/^Error\:.+/, '')
@@ -122,9 +122,9 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     retry_count.times do |n|
       begin
         if host
-          out = mongo([db, '--quiet', '--host', host, '--eval', cmd])
+          out = mongo([db, '--quiet', '--ipv6', '--host', host, '--eval', cmd])
         else
-          out = mongo([db, '--quiet', '--host', get_conn_string, '--eval', cmd])
+          out = mongo([db, '--quiet', '--ipv6', '--host', get_conn_string, '--eval', cmd])
         end
       rescue => e
         Puppet.debug "Request failed: '#{e.message}' Retry: '#{n}'"


### PR DESCRIPTION
When the MongoDB server is configured to listen to an IPv6 address,
the mongo client needs to use the "--ipv6" command-line switch to
connect using IPv6 [1].

It is safe to enable IPv6 for all commands, as this is just enabling
support. Using an IPv4 address when specifying --ipv6 works fine.

[1] https://docs.mongodb.org/manual/reference/program/mongo/#cmdoption--ipv6