### PR TITLE
(MODULES-2983) Enable IPv6 in mongodb provider

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -28,6 +28,22 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     file
   end
 
+  def self.ipv6_is_enabled
+    file = get_mongod_conf_file
+    config = YAML.load_file(file)
+    if config.kind_of?(Hash)
+      ipv6 = config['net.ipv6']
+    else # It has to be a key-value store
+      config = {}
+      File.readlines(file).collect do |line|
+        k,v = line.split('=')
+        config[k.rstrip] = v.lstrip.chomp if k and v
+      end
+      ipv6 = config['ipv6']
+    end
+    ipv6
+  end
+
   def self.get_conn_string
     file = get_mongod_conf_file
     # The mongo conf is probably a key-value store, even though 2.6 is
@@ -55,8 +71,11 @@ class Puppet::Provider::Mongodb < Puppet::Provider
 
     if bindip
       first_ip_in_list = bindip.split(',').first
-      if first_ip_in_list.eql? '0.0.0.0'
+      case first_ip_in_list
+      when '0.0.0.0'
         ip_real = '127.0.0.1'
+      when /\[?::0\]?/
+        ip_real = '::1'
       else
         ip_real = first_ip_in_list
       end
@@ -80,7 +99,13 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     if mongorc_file
         cmd_ismaster = mongorc_file + cmd_ismaster
     end
-    out = mongo(['admin', '--quiet', '--host', get_conn_string, '--eval', cmd_ismaster])
+    has_ipv6 = ipv6_is_enabled
+    if has_ipv6
+      ipv6 = '--ipv6'
+    else
+      ipv6 = ''
+    end
+    out = mongo(['admin', '--quiet', ipv6, '--host', get_conn_string, '--eval', cmd_ismaster])
     out.gsub!(/ObjectId\(([^)]*)\)/, '\1')
     out.gsub!(/ISODate\((.+?)\)/, '\1 ')
     out.gsub!(/^Error\:.+/, '')
@@ -118,13 +143,19 @@ class Puppet::Provider::Mongodb < Puppet::Provider
         cmd = mongorc_file + cmd
     end
 
+    has_ipv6 = ipv6_is_enabled
+    if has_ipv6
+      ipv6 = '--ipv6'
+    else
+      ipv6 = ''
+    end
     out = nil
     retry_count.times do |n|
       begin
         if host
-          out = mongo([db, '--quiet', '--host', host, '--eval', cmd])
+          out = mongo([db, '--quiet', ipv6, '--host', host, '--eval', cmd])
         else
-          out = mongo([db, '--quiet', '--host', get_conn_string, '--eval', cmd])
+          out = mongo([db, '--quiet', ipv6, '--host', get_conn_string, '--eval', cmd])
         end
       rescue => e
         Puppet.debug "Request failed: '#{e.message}' Retry: '#{n}'"


### PR DESCRIPTION
This patch allows to run mongodb providers on ipv6 networks.

* When ipv6 is enabled in MongoDB configuration, add --ipv6 when running
  MongoDB Client [1].
* When bindip is '::0', ip_real will be '[::1]' to be consistent with
  ipv4 logic.

[1] https://docs.mongodb.org/manual/reference/program/mongo/#cmdoption--ipv6

Co-Authored-By: Javier Peña <jpena@redhat.com>
Co-Authored-By: Sofer Athlan Guyot <sathlang@redhat.com>