### PR TITLE
Additional javascript objects causing failure.

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -268,6 +268,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, :parent => Puppet::Provider:
     # Dirty hack to remove JavaScript objects
     output.gsub!(/ISODate\((.+?)\)/, '\1 ')
     output.gsub!(/Timestamp\((.+?)\)/, '[\1]')
+    output.gsub!(/NumberLong\((.+?)\)/, '\1')
 
     #Hack to avoid non-json empty sets
     output = "{}" if output == "null\n"

--- a/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
+++ b/spec/unit/puppet/provider/mongodb_replset/mongodb_spec.rb
@@ -152,6 +152,7 @@ EOT
 	"me" : "mongo1:27017",
 	"maxBsonObjectSize" : 16777216,
 	"maxMessageSizeBytes" : 48000000,
+	"pingMs" : NumberLong(0),
 	"localTime" : ISODate("2014-01-10T19:31:51.281Z"),
 	"ok" : 1
 }


### PR DESCRIPTION
I found additional javascript objects in my json output that was causing
the json parsing to fail. I've added them to the list of things to gsub
out.