### PR TITLE
Remove empty lines between doc and definition

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -1,6 +1,5 @@
 # Class for setting cross-class global overrides. See README.md for more
 # details.
-
 class mongodb::globals (
   $server_package_name   = undef,
   $client_package_name   = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,7 +32,6 @@
 #
 # Copyright 2013 PuppetLabs
 #
-
 class mongodb (
   # Deprecated parameters
   $enable_10gen    = undef,

--- a/manifests/replset.pp
+++ b/manifests/replset.pp
@@ -1,5 +1,4 @@
 # Wrapper class useful for hiera based deployments
-
 class mongodb::replset(
   $sets = undef
 ) {

--- a/manifests/shardsvr.pp
+++ b/manifests/shardsvr.pp
@@ -1,5 +1,4 @@
 # Wrapper class useful for hiera based deployments
-
 class mongodb::shardsvr(
   $shards = undef
 ) {


### PR DESCRIPTION
Otherwise our linting complains because puppet doc apparently won't pick
up the documentation in such a state.