### PR TITLE
ensure that the pidfile exists and is writable to the mongod service

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -206,6 +206,15 @@ class mongodb::server::config {
       group   => $group,
       require => File[$config]
     }
+
+    if $pidfilepath {
+      file { $pidfilepath:
+        ensure => file,
+        mode   => '0644',
+        owner  => $user,
+        group  => $group,
+      }
+    }
   } else {
     file { $dbpath:
       ensure => absent,


### PR DESCRIPTION
Fixes [MODULES-3085](https://tickets.puppetlabs.com/browse/MODULES-3085), crashes mongodb when changing pidfile location.