### PR TITLE
MongoDB 2.6 SSL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ For Red Hat family systems, the client can be installed in a similar fashion:
 class {'::mongodb::client':}
 ```
 
-Note that for Debian/Ubuntu family systems the client is installed with the 
+Note that for Debian/Ubuntu family systems the client is installed with the
 server. Using the client class will by default install the server.
 
 If one plans to configure sharding for a Mongo deployment, the module offer
@@ -427,11 +427,11 @@ class mongodb::server {
 Set to true to enable a simple REST interface. Default: false
 
 #####`quiet`
-Runs the mongod or mongos instance in a quiet mode that attempts to limit the 
+Runs the mongod or mongos instance in a quiet mode that attempts to limit the
 amount of output. This option suppresses : "output from database commands, including drop, dropIndexes, diagLogging, validate, and clean", "replication activity", "connection accepted events" and "connection closed events".
 Default: false
 
-> For production systems this option is **not** recommended as it may make tracking 
+> For production systems this option is **not** recommended as it may make tracking
 problems during particular connections much more difficult.
 
 #####`slowms`
@@ -476,8 +476,9 @@ this slave instance will replicate. Default: <>
 
 #####`ssl`
 Set to true to enable ssl. Default: <>
-*Important*: You need to have ssl_key and ssl_ca set as well and files
-need to pre-exist on node.
+*Important*: You need to have ssl_key set as well, and the file needs to
+pre-exist on node. If you wish to use certificate validation, ssl_ca must also
+be set.
 
 #####`ssl_key`
 Default: <>

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -108,7 +108,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
   def self.db_ismaster
     cmd_ismaster = 'printjson(db.isMaster())'
     if mongorc_file
-        cmd_ismaster = mongorc_file + cmd_ismaster
+      cmd_ismaster = mongorc_file + cmd_ismaster
     end
     db = 'admin'
     out = mongo_cmd(db, get_conn_string, cmd_ismaster)
@@ -134,7 +134,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
     retry_count = retries
     retry_sleep = 3
     if mongorc_file
-        cmd = mongorc_file + cmd
+      cmd = mongorc_file + cmd
     end
 
     out = nil

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -67,11 +67,10 @@ class Puppet::Provider::Mongodb < Puppet::Provider
   end
 
   def self.mongo_cmd(db, host, cmd)
-    if ipv6_is_enabled
-      out = mongo([db, '--quiet', '--ipv6', '--host', host, '--eval', cmd])
-    else
-      out = mongo([db, '--quiet', '--host', host, '--eval', cmd])
-    end
+    args = [db, '--quiet', '--host', host]
+    args.push('--ipv6') if ipv6_is_enabled
+    args += ['--eval', cmd]
+    mongo(args)
   end
 
   def self.get_conn_string

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -132,6 +132,9 @@ class mongodb::server::config {
       # - $shardsvr
       # - $slowms
       # - $smallfiles
+      # - $ssl
+      # - $ssl_ca
+      # - $ssl_key
       # - $syslog
       # - $verbose
       # - $verbositylevel

--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -102,6 +102,13 @@ net.maxIncomingConnections: <%= @maxconns %>
 <% if ! @nohttpinterface.nil? -%>
 net.http.enabled: <%= ! @nohttpinterface %>
 <% end -%>
+<% if @ssl -%>
+net.ssl.mode: requireSSL
+net.ssl.PEMKeyFile: <%= @ssl_key %>
+<% if @ssl_ca -%>
+net.ssl.CAFile: <%= @ssl_ca %>
+<% end -%>
+<% end -%>
 
 #Replication
 <% if @replset -%>

--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -186,5 +186,7 @@ quiet = <%= @quiet %>
 <% if @ssl -%>
 sslOnNormalPorts = true
 sslPEMKeyFile = <%= @ssl_key %>
+<% if @ssl_ca -%>
 sslCAFile = <%= @ssl_ca %>
+<% end -%>
 <% end -%>


### PR DESCRIPTION
Adds support for configuring SSL for MongoDB 2.6.