### PR TITLE
parse NumberLong from result to get valid json 

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,3 +744,4 @@ We would like to thank everyone who has contributed issues and pull requests to 
 A complete list of contributors can be found on the
 [GitHub Contributor Graph](https://github.com/puppetlabs/puppetlabs-mongodb/graphs/contributors)
 for the [puppetlabs-mongodb module](https://github.com/puppetlabs/puppetlabs-mongodb).
+

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -166,9 +166,9 @@ class Puppet::Provider::Mongodb < Puppet::Provider
       raise Puppet::ExecutionFailure, "Could not evalute MongoDB shell command: #{cmd}"
     end
 
-    ['ObjectId','NumberLong'].each do |data_type|
-       out.gsub!(/#{data_type}\(([^)]*)\)/, '\1')
-    end
+    #['ObjectId','NumberLong'].each do |data_type|
+    out.gsub!(/ObjectId\(([^)]*)\)/, '\1')
+    #end
     out.gsub!(/^Error\:.+/, '')
     out
   end

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -166,9 +166,9 @@ class Puppet::Provider::Mongodb < Puppet::Provider
       raise Puppet::ExecutionFailure, "Could not evalute MongoDB shell command: #{cmd}"
     end
 
-    #['ObjectId','NumberLong'].each do |data_type|
-    out.gsub!(/ObjectId\(([^)]*)\)/, '\1')
-    #end
+    ['ObjectId','NumberLong'].each do |data_type|
+      out.gsub!(/#{data_type}\(([^)]*)\)/, '\1')
+    end
     out.gsub!(/^Error\:.+/, '')
     out
   end

--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -166,7 +166,9 @@ class Puppet::Provider::Mongodb < Puppet::Provider
       raise Puppet::ExecutionFailure, "Could not evalute MongoDB shell command: #{cmd}"
     end
 
-    out.gsub!(/ObjectId\(([^)]*)\)/, '\1')
+    ['ObjectId','NumberLong'].each do |data_type|
+       out.gsub!(/#{data_type}\(([^)]*)\)/, '\1')
+    end
     out.gsub!(/^Error\:.+/, '')
     out
   end


### PR DESCRIPTION
With the current mongodb module version we're getting an error, when creating an replicaset. By parsing NumberLong from the response this issue is fixed.

Error: /Stage[main]/Mongodb::Replset/Mongodb_replset[rsmain]: Could not evaluate: 751: unexpected token at '{
	"_id" : "rsmain",
	"version" : 1,
	"protocolVersion" : NumberLong(1),
	"members" : [
		{
			"_id" : 0,
			"host" : "localhost:27017",
			"arbiterOnly" : false,
			"buildIndexes" : true,
			"hidden" : false,
			"priority" : 1,
			"tags" : {
				
			},
			"slaveDelay" : NumberLong(0),
			"votes" : 1
		}
	],
	"settings" : {
		"chainingAllowed" : true,
		"heartbeatIntervalMillis" : 2000,
		"heartbeatTimeoutSecs" : 10,
		"electionTimeoutMillis" : 10000,
		"getLastErrorModes" : {
			
		},
		"getLastErrorDefaults" : {
			"w" : 1,
			"wtimeout" : 0
		}
	}
}
'