### PR TITLE
parse NumberLong data type from mongodb outputs to generate valid json

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -166,7 +166,9 @@ class Puppet::Provider::Mongodb < Puppet::Provider
       raise Puppet::ExecutionFailure, "Could not evalute MongoDB shell command: #{cmd}"
     end
 
-    out.gsub!(/ObjectId\(([^)]*)\)/, '\1')
+    ['ObjectId','NumberLong'].each do |data_type|
+      out.gsub!(/#{data_type}\(([^)]*)\)/, '\1')
+    end
     out.gsub!(/^Error\:.+/, '')
     out
   end


### PR DESCRIPTION
Fixes error:
Error: /Stage[main]/Mongodb::Replset/Mongodb_replset[rsmain]: Could not evaluate: 751: unexpected token at '{
	"_id" : "rsmain",
	"version" : 1,
	"protocolVersion" : NumberLong(1),
	"members" : [
		{
			"_id" : 0,
			"host" : "localhost:27017",
			"arbiterOnly" : false,
			"buildIndexes" : true,
			"hidden" : false,
			"priority" : 1,
			"tags" : {
				
			},
			"slaveDelay" : NumberLong(0),
			"votes" : 1
		}
	],
	"settings" : {
		"chainingAllowed" : true,
		"heartbeatIntervalMillis" : 2000,
		"heartbeatTimeoutSecs" : 10,
		"electionTimeoutMillis" : 10000,
		"getLastErrorModes" : {
			
		},
		"getLastErrorDefaults" : {
			"w" : 1,
			"wtimeout" : 0
		}
	}
}
'

