### PR TITLE
(MODULES-3120) add $maxconns to mongodb::server::config

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -55,6 +55,7 @@ class mongodb::server::config {
   $bind_ip         = $mongodb::server::bind_ip
   $directoryperdb  = $mongodb::server::directoryperdb
   $profile         = $mongodb::server::profile
+  $maxconns        = $mongodb::server::maxconns
   $set_parameter   = $mongodb::server::set_parameter
   $syslog          = $mongodb::server::syslog
   $ssl             = $mongodb::server::ssl


### PR DESCRIPTION
if using future parser $maxconns inside the template is missing,
add $maxconns to mongodb::server::config