### PR TITLE
(MODULES-3170) Add `db_name` param to mongodb::db defined type

### DIFF
--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -5,6 +5,7 @@
 # == Parameters
 #
 #  user - Database username.
+#  db_name - Database name. Defaults to $name.
 #  password_hash - Hashed password. Hex encoded md5 hash of "$username:mongo:$password".
 #  password - Plain text user password. This is UNSAFE, use 'password_hash' unstead.
 #  roles (default: ['dbAdmin']) - array with user roles.
@@ -12,13 +13,14 @@
 #
 define mongodb::db (
   $user,
+  $db_name       = $name,
   $password_hash = false,
   $password      = false,
   $roles         = ['dbAdmin'],
   $tries         = 10,
 ) {
 
-  mongodb_database { $name:
+  mongodb_database { $db_name:
     ensure => present,
     tries  => $tries
   }
@@ -31,13 +33,13 @@ define mongodb::db (
     fail("Parameter 'password_hash' or 'password' should be provided to mongodb::db.")
   }
 
-  mongodb_user { "User ${user} on db ${name}":
+  mongodb_user { "User ${user} on db ${db_name}":
     ensure        => present,
     password_hash => $hash,
     username      => $user,
-    database      => $name,
+    database      => $db_name,
     roles         => $roles,
-    require       => Mongodb_database[$name],
+    require       => Mongodb_database[$db_name],
   }
 
 }

--- a/spec/defines/db_spec.rb
+++ b/spec/defines/db_spec.rb
@@ -1,40 +1,83 @@
 require 'spec_helper'
 
 describe 'mongodb::db', :type => :define do
-  let(:title) { 'testdb' }
+  context 'default' do
+    let(:title) { 'testdb' }
 
-  let(:params) {
-    { 'user'     => 'testuser',
-      'password' => 'testpass',
+    let(:params) {
+      { 'user'     => 'testuser',
+        'password' => 'testpass',
+      }
     }
-  }
 
-  it 'should contain mongodb_database with mongodb::server requirement' do
-    is_expected.to contain_mongodb_database('testdb')
+    it 'should contain mongodb_database with mongodb::server requirement' do
+      is_expected.to contain_mongodb_database('testdb')
+    end
+
+    it 'should contain mongodb_user with mongodb_database requirement' do
+      is_expected.to contain_mongodb_user('User testuser on db testdb').with({
+        'username' => 'testuser',
+        'database' => 'testdb',
+        'require'  => 'Mongodb_database[testdb]',
+      })
+    end
+
+    it 'should contain mongodb_user with proper roles' do
+      params.merge!({'roles' => ['testrole1', 'testrole2']})
+      is_expected.to contain_mongodb_user('User testuser on db testdb')\
+        .with_roles(["testrole1", "testrole2"])
+    end
+
+    it 'should prefer password_hash instead of password' do
+      params.merge!({'password_hash' => 'securehash'})
+      is_expected.to contain_mongodb_user('User testuser on db testdb')\
+        .with_password_hash('securehash')
+    end
+
+    it 'should contain mongodb_database with proper tries param' do
+      params.merge!({'tries' => 5})
+      is_expected.to contain_mongodb_database('testdb').with_tries(5)
+    end
   end
 
-  it 'should contain mongodb_user with mongodb_database requirement' do
-    is_expected.to contain_mongodb_user('User testuser on db testdb').with({
-      'username' => 'testuser',
-      'database' => 'testdb',
-      'require'  => 'Mongodb_database[testdb]',
-    })
-  end
+  context 'with a db_name value' do
+    let(:title) { 'testdb-title' }
 
-  it 'should contain mongodb_user with proper roles' do
-    params.merge!({'roles' => ['testrole1', 'testrole2']})
-    is_expected.to contain_mongodb_user('User testuser on db testdb')\
-      .with_roles(["testrole1", "testrole2"])
-  end
+    let(:params) {
+      { 
+        'db_name'  => 'testdb',
+        'user'     => 'testuser',
+        'password' => 'testpass',
+      }
+    }
 
-  it 'should prefer password_hash instead of password' do
-    params.merge!({'password_hash' => 'securehash'})
-    is_expected.to contain_mongodb_user('User testuser on db testdb')\
-      .with_password_hash('securehash')
-  end
+    it 'should contain mongodb_database with mongodb::server requirement' do
+      is_expected.to contain_mongodb_database('testdb')
+    end
 
-  it 'should contain mongodb_database with proper tries param' do
-    params.merge!({'tries' => 5})
-    is_expected.to contain_mongodb_database('testdb').with_tries(5)
+    it 'should contain mongodb_user with mongodb_database requirement' do
+      is_expected.to contain_mongodb_user('User testuser on db testdb').with({
+        'username' => 'testuser',
+        'database' => 'testdb',
+        'require'  => 'Mongodb_database[testdb]',
+      })
+    end
+
+    it 'should contain mongodb_user with proper roles' do
+      params.merge!({'roles' => ['testrole1', 'testrole2']})
+      is_expected.to contain_mongodb_user('User testuser on db testdb')\
+        .with_roles(["testrole1", "testrole2"])
+    end
+
+    it 'should prefer password_hash instead of password' do
+      params.merge!({'password_hash' => 'securehash'})
+      is_expected.to contain_mongodb_user('User testuser on db testdb')\
+        .with_password_hash('securehash')
+    end
+
+    it 'should contain mongodb_database with proper tries param' do
+      params.merge!({'tries' => 5})
+      is_expected.to contain_mongodb_database('testdb').with_tries(5)
+    end
   end
 end


### PR DESCRIPTION
(MODULES-3170) Add `db_name` param to `mongodb::db` defined type to allow unique resource titles when exporting the resource.