### PR TITLE
Revert "(MODULES-3236) Update mongoDB 3.x bindIp configuration parame…

### DIFF
--- a/spec/classes/server_config_spec.rb
+++ b/spec/classes/server_config_spec.rb
@@ -22,7 +22,7 @@ describe 'mongodb::server::config', :type => :class do
       })
 
       is_expected.to contain_file('/etc/mongod.conf').with_content(/^dbpath=\/var\/lib\/mongo/)
-      is_expected.to contain_file('/etc/mongod.conf').with_content(/bindIp\s=\s0\.0\.0\.0/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/bind_ip\s=\s0\.0\.0\.0/)
       is_expected.to contain_file('/etc/mongod.conf').with_content(/^port = 29017$/)
       is_expected.to contain_file('/etc/mongod.conf').with_content(/^logappend=true/)
       is_expected.to contain_file('/etc/mongod.conf').with_content(/^logpath=\/var\/log\/mongo\/mongod\.log/)
@@ -53,7 +53,7 @@ describe 'mongodb::server::config', :type => :class do
     let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $bind_ip = ['127.0.0.1', 'fd00:beef:dead:55::143'] $ipv6 = true }", "include mongodb::server"]}
 
     it {
-      is_expected.to contain_file('/etc/mongod.conf').with_content(/bindIp\s=\s127\.0\.0\.1\,fd00:beef:dead:55::143/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/bind_ip\s=\s127\.0\.0\.1\,fd00:beef:dead:55::143/)
       is_expected.to contain_file('/etc/mongod.conf').with_content(/ipv6=true/)
     }
   end
@@ -62,7 +62,7 @@ describe 'mongodb::server::config', :type => :class do
     let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $bind_ip = ['127.0.0.1', '10.1.1.13']}", "include mongodb::server"]}
 
     it {
-      is_expected.to contain_file('/etc/mongod.conf').with_content(/bindIp\s=\s127\.0\.0\.1\,10\.1\.1\.13/)
+      is_expected.to contain_file('/etc/mongod.conf').with_content(/bind_ip\s=\s127\.0\.0\.1\,10\.1\.1\.13/)
     }
   end
 

--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -15,7 +15,7 @@ ipv6=<%= @ipv6 %>
 # Set this option to configure the mongod or mongos process to bind to and
 # listen for connections from applications on this address.
 # You may concatenate a list of comma separated values to bind mongod to multiple IP addresses.
-bindIp = <%= Array(@bind_ip).join(',') %>
+bind_ip = <%= Array(@bind_ip).join(',') %>
 <% end -%>
 <% if @fork -%>
 # fork and run in background


### PR DESCRIPTION
…ter"

This commit wasn't compatable with mongodb 2.x
https://bugs.launchpad.net/tripleo/+bug/1567831

This reverts commit c2d92004bdc5b6e3d0ac5bbc9c70e312100c0725.