### PR TITLE
(maint) fixing STRICT_VARIABLE testing

### DIFF
--- a/manifests/mongos.pp
+++ b/manifests/mongos.pp
@@ -5,7 +5,7 @@ class mongodb::mongos (
   $config_content   = undef,
   $configdb         = $mongodb::params::mongos_configdb,
   $service_manage   = $mongodb::params::mongos_service_manage,
-  $service_provider = $mongodb::params::mongos_service_provider,
+  $service_provider = undef,
   $service_name     = $mongodb::params::mongos_service_name,
   $service_enable   = $mongodb::params::mongos_service_enable,
   $service_ensure   = $mongodb::params::mongos_service_ensure,

--- a/spec/classes/mongos_config_spec.rb
+++ b/spec/classes/mongos_config_spec.rb
@@ -3,13 +3,7 @@ require 'spec_helper'
 describe 'mongodb::mongos::config' do
 
   describe 'it should create mongos configuration file' do
-
-    let :facts do
-      {
-        :osfamily        => 'Debian',
-        :operatingsystem => 'Debian',
-      }
-    end
+    with_debian_facts
 
     let :pre_condition do
       "class { 'mongodb::mongos': }"

--- a/spec/classes/mongos_install_spec.rb
+++ b/spec/classes/mongos_install_spec.rb
@@ -3,13 +3,7 @@ require 'spec_helper'
 describe 'mongodb::mongos::install', :type => :class do
 
   describe 'it should include package' do
-
-    let :facts do
-      {
-        :osfamily        => 'Debian',
-        :operatingsystem => 'Debian',
-      }
-    end
+    with_debian_facts
 
     let :pre_condition do
       "class { 'mongodb::mongos':

--- a/spec/classes/mongos_service_spec.rb
+++ b/spec/classes/mongos_service_spec.rb
@@ -3,19 +3,13 @@ require 'spec_helper'
 describe 'mongodb::mongos::service', :type => :class do
 
   context 'on Debian with service_manage set to true' do
-    let :facts do
-      {
-        :osfamily               => 'Debian',
-        :operatingsystem        => 'Debian',
-        :operatingsystemrelease => '7.0',
-      }
-    end
+    with_debian_facts
 
-    let :pre_condition do          
+    let :pre_condition do
       "class { 'mongodb::mongos':
          configdb => ['127.0.0.1:27019'],
        }"
-    end 
+    end
 
     describe 'include init script' do
       it { is_expected.to contain_file('/etc/init.d/mongos') }
@@ -28,13 +22,7 @@ describe 'mongodb::mongos::service', :type => :class do
   end
 
   context 'on Debian with service_manage set to false' do
-    let :facts do
-      {
-        :osfamily               => 'Debian',
-        :operatingsystem        => 'Debian',
-        :operatingsystemrelease => '7.0',
-      }
-    end
+    with_debian_facts
 
     let :pre_condition do
       "class { 'mongodb::mongos':
@@ -50,13 +38,7 @@ describe 'mongodb::mongos::service', :type => :class do
   end
 
   context 'on RedHat with service_manage set to true' do
-    let :facts do
-      {
-        :osfamily               => 'RedHat',
-        :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => '7.0',
-      }
-    end
+    with_redhat_facts
 
     let :pre_condition do
       "class { 'mongodb::mongos':
@@ -79,13 +61,7 @@ describe 'mongodb::mongos::service', :type => :class do
   end
 
   context 'on RedHat with service_manage set to false' do
-    let :facts do
-      {
-        :osfamily               => 'RedHat',
-        :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => '7.0',
-      }
-    end
+    with_redhat_facts
 
     let :pre_condition do
       "class { 'mongodb::mongos':

--- a/spec/classes/mongos_spec.rb
+++ b/spec/classes/mongos_spec.rb
@@ -1,12 +1,7 @@
 require 'spec_helper'
 
 describe 'mongodb::mongos' do
-  let :facts do
-    {
-      :osfamily        => 'Debian',
-      :operatingsystem => 'Debian',
-    }
-  end
+  with_debian_facts
 
   let :params do
     {

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -3,14 +3,7 @@ require 'spec_helper'
 describe 'mongodb::repo', :type => :class do
 
   context 'when deploying on Debian' do
-    let :facts do
-      {
-        :osfamily               => 'Debian',
-        :operatingsystem        => 'Debian',
-        :operatingsystemrelease => '7.0',
-        :lsbdistid              => 'Debian',
-      }
-    end
+    with_debian_facts
 
     it {
       is_expected.to contain_class('mongodb::repo::apt')
@@ -18,13 +11,7 @@ describe 'mongodb::repo', :type => :class do
   end
 
   context 'when deploying on CentOS' do
-    let :facts do
-      {
-        :osfamily               => 'RedHat',
-        :operatingsystem        => 'CentOS',
-        :operatingsystemrelease => '7.0',
-      }
-    end
+    with_centos_facts
 
     it {
       is_expected.to contain_class('mongodb::repo::yum')
@@ -32,13 +19,8 @@ describe 'mongodb::repo', :type => :class do
   end
 
   context 'when yumrepo has a proxy set' do
-    let :facts do
-      {
-        :osfamily               => 'RedHat',
-        :operatingsystem        => 'RedHat',
-        :operatingsystemrelease => '7.0',
-      }
-    end
+    with_redhat_facts
+
     let :params do
       {
         :proxy => 'http://proxy-server:8080',

--- a/spec/classes/server_config_spec.rb
+++ b/spec/classes/server_config_spec.rb
@@ -1,9 +1,10 @@
 require 'spec_helper'
 
 describe 'mongodb::server::config', :type => :class do
+  with_debian_facts
 
-  describe 'with preseted variables' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' }", "include mongodb::server"]}
+  describe 'with preset variables' do
+    let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js' }" }
 
     it {
       is_expected.to contain_file('/etc/mongod.conf')
@@ -12,7 +13,7 @@ describe 'mongodb::server::config', :type => :class do
   end
 
   describe 'with default values' do
-    let(:pre_condition) {[ "class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $create_admin = false $rcfile = '/root/.mongorc.js' $store_creds = true $ensure = present $user = 'mongod' $group = 'mongod' $port = 29017 $bind_ip = ['0.0.0.0'] $fork = true $logpath ='/var/log/mongo/mongod.log' $logappend = true }",  "include mongodb::server" ]}
+    let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', dbpath => '/var/lib/mongo', create_admin => false, rcfile => '/root/.mongorc.js', store_creds => true, ensure => present, user => 'mongod', group => 'mongod', port => 29017, bind_ip => ['0.0.0.0'], fork => true, logpath => '/var/log/mongo/mongod.log', logappend => true }" }
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with({
@@ -33,7 +34,7 @@ describe 'mongodb::server::config', :type => :class do
   end
 
   describe 'with absent ensure' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = absent }", "include mongodb::server"]}
+    let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js', ensure => absent }" }
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with({ :ensure => 'absent' })
@@ -41,16 +42,8 @@ describe 'mongodb::server::config', :type => :class do
 
   end
 
-  describe 'when specifying storage_engine' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.monogrc.js' $ensure = present $version='3.0.3' $storage_engine = 'SomeEngine' $storage_engine_internal = 'SomeEngine' $user = 'mongod' $group = 'mongod' $port = 29017 $bind_ip = ['0.0.0.0'] $fork = true $logpath ='/var/log/mongo/mongod.log' $logappend = true}", "include mongodb::server"]}
-
-    it {
-      is_expected.to contain_file('/etc/mongod.conf').with_content(/storage.engine:\sSomeEngine/)
-    }
-  end
-
   describe 'with specific bind_ip values and ipv6' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $bind_ip = ['127.0.0.1', 'fd00:beef:dead:55::143'] $ipv6 = true }", "include mongodb::server"]}
+    let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js', ensure => present, bind_ip => ['127.0.0.1', 'fd00:beef:dead:55::143'], ipv6 => true }" }
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with_content(/bindIp\s=\s127\.0\.0\.1\,fd00:beef:dead:55::143/)
@@ -59,7 +52,7 @@ describe 'mongodb::server::config', :type => :class do
   end
 
   describe 'with specific bind_ip values' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $bind_ip = ['127.0.0.1', '10.1.1.13']}", "include mongodb::server"]}
+    let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js', ensure => present, bind_ip => ['127.0.0.1', '10.1.1.13']}" }
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with_content(/bindIp\s=\s127\.0\.0\.1\,10\.1\.1\.13/)
@@ -67,16 +60,16 @@ describe 'mongodb::server::config', :type => :class do
   end
 
   describe 'when specifying auth to true' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $auth = true $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present }", "include mongodb::server"]}
+    let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', auth => true, dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js', ensure => present }" }
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with_content(/^auth=true/)
       is_expected.to contain_file('/root/.mongorc.js')
     }
   end
-  
+
   describe 'when specifying set_parameter value' do
-    let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $set_parameter = 'textSearchEnable=true' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present }", "include mongodb::server"]}
+    let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', set_parameter => 'textSearchEnable=true', dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js', ensure => present }" }
 
     it {
       is_expected.to contain_file('/etc/mongod.conf').with_content(/^setParameter = textSearchEnable=true/)
@@ -85,8 +78,8 @@ describe 'mongodb::server::config', :type => :class do
 
   describe 'with journal:' do
     context 'on true with i686 architecture' do
-      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $journal = true }", "include mongodb::server"]}
-      let (:facts) { { :architecture => 'i686' } }
+      let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js', ensure => present, journal => true }" }
+      let (:facts) { super().merge({ :architecture => 'i686' }) }
 
       it {
         is_expected.to contain_file('/etc/mongod.conf').with_content(/^journal = true/)
@@ -98,14 +91,14 @@ describe 'mongodb::server::config', :type => :class do
   describe 'with quota to' do
 
     context 'true and without quotafiles' do
-      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $quota = true }", "include mongodb::server"]}
+      let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js', ensure => present, quota => true }" }
       it {
         is_expected.to contain_file('/etc/mongod.conf').with_content(/^quota = true/)
       }
     end
 
     context 'true and with quotafiles' do
-      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $quota = true $quotafiles = 1 }", "include mongodb::server"]}
+      let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js', ensure => present, quota => true, quotafiles => 1 }" }
 
       it {
         is_expected.to contain_file('/etc/mongod.conf').with_content(/quota = true/)
@@ -116,7 +109,7 @@ describe 'mongodb::server::config', :type => :class do
 
   describe 'when specifying syslog value' do
     context 'it should be set to true' do
-      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $syslog = true }", "include mongodb::server"]}
+      let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js', ensure => present, syslog => true, logpath => false }" }
 
       it {
         is_expected.to contain_file('/etc/mongod.conf').with_content(/^syslog = true/)
@@ -124,7 +117,7 @@ describe 'mongodb::server::config', :type => :class do
     end
 
     context 'if logpath is also set an error should be raised' do
-      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $syslog = true $logpath ='/var/log/mongo/mongod.log' }", "include mongodb::server"]}
+      let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js', ensure => present, syslog => true, logpath => '/var/log/mongo/mongod.log' }" }
 
       it {
         expect { is_expected.to contain_file('/etc/mongod.conf') }.to raise_error(Puppet::Error, /You cannot use syslog with logpath/)
@@ -134,8 +127,8 @@ describe 'mongodb::server::config', :type => :class do
   end
 
   describe 'with store_creds' do
-    context 'true' do 
-      let(:pre_condition) { ["class mongodb::server { $admin_username = 'admin' $admin_password = 'password' $auth = true $store_creds = true $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present }", "include mongodb::server"]}
+    context 'true' do
+      let(:pre_condition) { "class { 'mongodb::server': admin_username => 'admin', admin_password => 'password', auth => true, store_creds => true, config => '/etc/mongod.conf', dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js', ensure => present }" }
 
       it {
         is_expected.to contain_file('/root/.mongorc.js').
@@ -148,7 +141,7 @@ describe 'mongodb::server::config', :type => :class do
     end
 
     context 'false' do
-      let(:pre_condition) { ["class mongodb::server { $config = '/etc/mongod.conf' $dbpath = '/var/lib/mongo' $rcfile = '/root/.mongorc.js' $ensure = present $store_creds = false  }", "include mongodb::server"]}
+      let(:pre_condition) { "class { 'mongodb::server': config => '/etc/mongod.conf', dbpath => '/var/lib/mongo', rcfile => '/root/.mongorc.js', ensure => present, store_creds => false  }" }
 
       it {
         is_expected.to contain_file('/root/.mongorc.js').with_ensure('absent')

--- a/spec/classes/server_spec.rb
+++ b/spec/classes/server_spec.rb
@@ -3,8 +3,10 @@ require 'spec_helper'
 describe 'mongodb::server' do
   let :facts do
     {
-      :osfamily        => 'Debian',
       :operatingsystem => 'Debian',
+      :operatingsystemmajrelease => 8,
+      :osfamily        => 'Debian',
+      :root_home       => '/root',
     }
   end
 
@@ -18,7 +20,7 @@ describe 'mongodb::server' do
   end
 
   context 'with create_admin => true' do
-    let(:params) do 
+    let(:params) do
       {
         :create_admin   => true,
         :admin_username => 'admin',

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,3 +6,40 @@ begin
   require 'spec_helper_local'
 rescue LoadError
 end
+
+def with_debian_facts
+  let :facts do
+    {
+      :lsbdistid       => 'Debian',
+      :lsbdistcodename => 'jessie',
+      :operatingsystem => 'Debian',
+      :operatingsystemmajrelease => 8,
+      :osfamily        => 'Debian',
+      :root_home       => '/root',
+    }
+  end
+end
+
+def with_centos_facts
+  let :facts do
+    {
+      :architecture           => 'x86_64',
+      :operatingsystem        => 'CentOS',
+      :operatingsystemrelease => '7.0',
+      :osfamily               => 'RedHat',
+      :root_home              => '/root',
+    }
+  end
+end
+
+def with_redhat_facts
+  let :facts do
+    {
+      :architecture           => 'x86_64',
+      :operatingsystem        => 'RedHat',
+      :operatingsystemrelease => '7.0',
+      :osfamily               => 'RedHat',
+      :root_home              => '/root',
+    }
+  end
+end


### PR DESCRIPTION
When moving to rspec-puppet 2.4.0, STRICT_VARIABLE testing was activated
for real. This commit adjusts the tests to pass all required facts into
the specs. Additionally, it cleans up the server_config_spec to actually
test stuff.