### PR TITLE
Use Facter::Util::Resolution instead of Facter::Core

### DIFF
--- a/lib/facter/mongodb_version.rb
+++ b/lib/facter/mongodb_version.rb
@@ -1,7 +1,7 @@
 Facter.add(:mongodb_version) do
   setcode do
-    if Facter::Core::Execution.which('mongo')
-      mongodb_version = Facter::Core::Execution.execute('mongo --version 2>&1')
+    if Facter::Util::Resolution.which('mongo')
+      mongodb_version = Facter::Util::Resolution.exec('mongo --version 2>&1')
       %r{^MongoDB shell version: ([\w\.]+)}.match(mongodb_version)[1]
     end
   end


### PR DESCRIPTION
This makes the module compatible with more setups, especially those with
older versions of facter.

EPEL for RHEL6 only has Facter 1.6 for example...