### PR TITLE
Add systemd service provider for Xenial deployment

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -205,7 +205,11 @@ class mongodb::params inherits mongodb::globals {
       }
     }
     'Ubuntu': {
-      $service_provider = pick($service_provider, 'upstart')
+      if versioncmp($::operatingsystemmajrelease, '16') >= 0 {
+        $service_provider = pick($service_provider, 'systemd')
+      } else {
+        $service_provider = pick($service_provider, 'upstart')
+      }
     }
     default: {
       $service_provider = undef


### PR DESCRIPTION
This patch adds systemd service provider in the case of using
Ubuntu 16.04 (Xenial). For older Ubuntu versions will be used
upstart service provider.