### PR TITLE
Allow hyphens in database names.

### DIFF
--- a/lib/puppet/type/mongodb_database.rb
+++ b/lib/puppet/type/mongodb_database.rb
@@ -5,7 +5,7 @@ Puppet::Type.newtype(:mongodb_database) do
 
   newparam(:name, :namevar=>true) do
     desc "The name of the database."
-    newvalues(/^\w+$/)
+    newvalues(/^(\w|-)+$/)
   end
 
   newparam(:tries) do


### PR DESCRIPTION
Not all non-word characters are invalid in MongoDB database names (see https://docs.mongodb.com/manual/reference/limits/#naming-restrictions).

This change prevents the mongodb_database type from failing validation on a database name that contains a hyphen character, which is one of the ones that MongoDB has no problems with.