### PR TITLE
(MODULES-3415) Make the is_master fact work when there are ObjectId values in the db.isMaster() response

### DIFF
--- a/lib/facter/is_master.rb
+++ b/lib/facter/is_master.rb
@@ -5,7 +5,7 @@ Facter.add('mongodb_is_master') do
     if Facter::Core::Execution.which('mongo') 
       e = File.exists?('/root/.mongorc.js') ? 'load(\'/root/.mongorc.js\'); ' : ''
       mongo_output = Facter::Core::Execution.exec("mongo --quiet --eval \"#{e}printjson(db.isMaster())\"")
-      JSON.parse(mongo_output.gsub(/ISODate\((.+?)\)/, '\1 ').gsub(/ObjectId\((.+?)\)/, '\1 '))['ismaster'] ||= false
+      JSON.parse(mongo_output.gsub(/ISODate\((.+?)\)/, '\1 ').gsub(/ObjectId\(([^)]*)\)/, '\1'))['ismaster'] ||= false
     else 
       'not_installed'
     end

--- a/lib/facter/is_master.rb
+++ b/lib/facter/is_master.rb
@@ -5,7 +5,7 @@ Facter.add('mongodb_is_master') do
     if Facter::Core::Execution.which('mongo') 
       e = File.exists?('/root/.mongorc.js') ? 'load(\'/root/.mongorc.js\'); ' : ''
       mongo_output = Facter::Core::Execution.exec("mongo --quiet --eval \"#{e}printjson(db.isMaster())\"")
-      JSON.parse(mongo_output.gsub(/ISODate\((.+?)\)/, '\1 '))['ismaster'] ||= false
+      JSON.parse(mongo_output.gsub(/ISODate\((.+?)\)/, '\1 ').gsub(/ObjectId\((.+?)\)/, '\1 '))['ismaster'] ||= false
     else 
       'not_installed'
     end


### PR DESCRIPTION
On my MongoDb 3.2 replicaset members, I was getting errors like "Could not retrieve fact='mongodb_is_master', resolution='<anonymous>': 757: unexpected token at  {(config response here)}".

From v3.0 onwards, the response to the db.isMaster() call includes an 'electionId' entry with an ObjectId value (See https://docs.mongodb.com/manual/reference/command/isMaster/#dbcmd.isMaster), which could not be parsed as standard JSON. 

This pull request works around the problem by converting the ObjectId to its string representation before attempting the parse.  It successfully resolves the issue and properly detects master or not on primary/secondary and arbiter members of the replicaset.
