### PR TITLE
Interpret the security.authorization configuration option correctly in versions of MongoDB >= 2.6

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -150,7 +150,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
 
   def self.auth_enabled(config=nil)
     config ||= get_mongo_conf
-    config['auth']
+    config['auth'] && config['auth'] != 'disabled'
   end
 
   # Mongo Command Wrapper


### PR DESCRIPTION
Since MongoDB 2.6, the security.authorization configuration parameter takes enabled/disabled as values rather than true/false. (See https://docs.mongodb.com/manual/reference/configuration-options/#security.authorization )

This means that the auth_enabled property needs to actually check the string value, rather than assuming it represents a boolean.