### PR TITLE
Mongo 3.2 sets "security.authorization" to "disabled"

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -69,7 +69,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, :parent => Puppet::Provider:
   end
 
   def rs_initiate(conf, master)
-    if auth_enabled
+    if auth_enabled && auth_enabled != 'disabled'
       return mongo_command("rs.initiate(#{conf})", initialize_host)
     else
       return mongo_command("rs.initiate(#{conf})", master)


### PR DESCRIPTION
Example `/etc/mongod.conf`:

    # cat /etc/mongod.conf
    #mongo.conf - generated from Puppet

    #System Log

    systemLog.path: /var/log/mongodb/mongodb.log
    systemLog.destination: file
    systemLog.logAppend: true
    systemLog.quiet: true

    #Process Management

    #Storage
    storage.dbPath: /var/lib/mongodb


    #Security
    security.authorization: disabled


    #Net
    net.bindIp:  172.16.50.9
    net.port: 27017

    #Replication
    replication.replSetName: rsmain

    #Sharding

    #Operation Profiling