### PR TITLE
Fix syntax error of net.ipv6 configuration option

### DIFF
--- a/templates/mongodb.conf.2.6.erb
+++ b/templates/mongodb.conf.2.6.erb
@@ -85,7 +85,7 @@ security.javascriptEnabled: <%= @noscripting %>
 
 #Net
 <% if @ipv6 -%>
-net.ipv6=<%= @ipv6 %>
+net.ipv6: <%= @ipv6 %>
 <% end -%>
 <% if @bind_ip -%>
 net.bindIp:  <%= Array(@bind_ip).join(',') %>


### PR DESCRIPTION
net.ipv6=true is not valid YAML syntax. This fixes it.
