### PR TITLE
Recursively manage the contents of dbpath directory

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -207,11 +207,14 @@ class mongodb::server::config {
     }
 
     file { $dbpath:
-      ensure  => directory,
-      mode    => '0755',
-      owner   => $user,
-      group   => $group,
-      require => File[$config],
+      ensure   => directory,
+      mode     => '0755',
+      owner    => $user,
+      group    => $group,
+      recurse  => true,
+      purge    => false,
+      checksum => 'none',
+      require  => File[$config],
     }
 
     if $pidfilepath {


### PR DESCRIPTION
Retain idempotency and manage all files recursively when
mongodb::server used on dbpath directory already containing the
data.

Signed-off-by: Maksim Malchuk <maksim.malchuk@gmail.com>