### PR TITLE
Only check if master if mongod installed

### DIFF
--- a/lib/facter/is_master.rb
+++ b/lib/facter/is_master.rb
@@ -2,7 +2,7 @@ require 'json';
 
 Facter.add('mongodb_is_master') do
   setcode do
-    if Facter::Core::Execution.which('mongo') 
+    if ['mongo', 'mongod'].all? {|m| Facter::Util::Resolution.which m}
       e = File.exists?('/root/.mongorc.js') ? 'load(\'/root/.mongorc.js\'); ' : ''
       mongo_output = Facter::Core::Execution.exec("mongo --quiet --eval \"#{e}printjson(db.isMaster())\"")
       JSON.parse(mongo_output.gsub(/ISODate\((.+?)\)/, '\1 ').gsub(/ObjectId\(([^)]*)\)/, '\1'))['ismaster'] ||= false


### PR DESCRIPTION
Stop the fact failing on machines that have the mongo client
installed, but arn't running the server.
