### PR TITLE
Recursively manage only user/group for dbpath

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class mongodb::params inherits mongodb::globals {
   $admin_username        = 'admin'
   $store_creds           = false
   $rcfile                = "${::root_home}/.mongorc.js"
+  $dbpath_fix            = true
 
   $mongos_service_manage = pick($mongodb::globals::mongos_service_manage, true)
   $mongos_service_enable = pick($mongodb::globals::mongos_service_enable, true)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -7,6 +7,7 @@ class mongodb::server (
 
   $config           = $mongodb::params::config,
   $dbpath           = $mongodb::params::dbpath,
+  $dbpath_fix       = $mongodb::params::dbpath_fix,
   $pidfilepath      = $mongodb::params::pidfilepath,
   $pidfilemode      = $mongodb::params::pidfilemode,
   $rcfile           = $mongodb::params::rcfile,


### PR DESCRIPTION
Retain idempotency and manage only user/group recursively when
mongodb::server used on dbpath directory already containing the
data. To retain the permissions and to speedup the operation the
unix 'chown' command used.

Signed-off-by: Maksim Malchuk maksim.malchuk@gmail.com
