### PR TITLE
Fix regex to be compatible with ruby 1.8.7

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -270,7 +270,7 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, :parent => Puppet::Provider:
     end
 
     # Dirty hack to remove JavaScript objects
-    output.gsub!(/\w+\((?!")(\d+).+?(?<!")\)/, '\1')  # Remove extra parameters from 'Timestamp(1462971623, 1)' Objects
+    output.gsub!(/\w+\((\d+).+?\)/, '\1')  # Remove extra parameters from 'Timestamp(1462971623, 1)' Objects
     output.gsub!(/\w+\((.+?)\)/, '\1')
 
     #Hack to avoid non-json empty sets


### PR DESCRIPTION
Current code uses some crazy regex stuff which doesn't exist in ruby 1.8.7, so I changed it to be simpler and compatible with 1.8.7.
