### PR TITLE
(MODULES-3684) Check if mongo is up before evaluating is_master fact

### DIFF
--- a/lib/facter/is_master.rb
+++ b/lib/facter/is_master.rb
@@ -1,12 +1,20 @@
-require 'json';
+require 'json'
 
 Facter.add('mongodb_is_master') do
   setcode do
-    if Facter::Core::Execution.which('mongo') 
+    if Facter::Core::Execution.which('mongo')
       e = File.exists?('/root/.mongorc.js') ? 'load(\'/root/.mongorc.js\'); ' : ''
-      mongo_output = Facter::Core::Execution.exec("mongo --quiet --eval \"#{e}printjson(db.isMaster())\"")
-      JSON.parse(mongo_output.gsub(/ISODate\((.+?)\)/, '\1 ').gsub(/ObjectId\(([^)]*)\)/, '\1'))['ismaster'] ||= false
-    else 
+
+      # Check if the mongodb server is responding:
+      Facter::Core::Execution.exec("mongo --quiet --eval \"#{e}printjson(db.adminCommand({ ping: 1 }))\"")
+
+      if $?.success?
+        mongo_output = Facter::Core::Execution.exec("mongo --quiet --eval \"#{e}printjson(db.isMaster())\"")
+        JSON.parse(mongo_output.gsub(/ISODate\((.+?)\)/, '\1 '))['ismaster'] ||= false
+      else
+        'not_responding'
+      end
+    else
       'not_installed'
     end
   end


### PR DESCRIPTION
Before:

```
[root@centos7-katello-p4 facter]# FACTERLIB=$PWD facter mongodb_is_master
2016-08-03 11:43:52.734246 ERROR puppetlabs.facter - error while resolving custom fact "mongodb_is_master":
757: unexpected token at '2016-08-03T11:43:52.731-0400 warning: Failed to connect to 127.0.0.1:27017, reason: errno:111 Connection refused
2016-08-03T11:43:52.732-0400 Error: couldn't connect to server 127.0.0.1:27017 (127.0.0.1), connection attempt failed at src/mongo/shell/mongo.js:146'
```

After:

```
[root@centos7-katello-p4 facter]# FACTERLIB=$PWD facter mongodb_is_master
not_responding
```
