### PR TITLE
Revert "Recursively manage the contents of dbpath directory"

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -210,14 +210,11 @@ class mongodb::server::config {
     }
 
     file { $dbpath:
-      ensure   => directory,
-      mode     => '0755',
-      owner    => $user,
-      group    => $group,
-      recurse  => true,
-      purge    => false,
-      checksum => 'none',
-      require  => File[$config],
+      ensure  => directory,
+      mode    => '0755',
+      owner   => $user,
+      group   => $group,
+      require => File[$config],
     }
 
     if $pidfilepath {


### PR DESCRIPTION
This reverts commit b9f97ea571f55ed18439d2f9363f4747ae219f18.
This commit broke idempotency:
/Stage[main]/Mongodb::Server::Config/File[/var/lib/mongodb/journal/j._0]/mode: mode changed '0600' to '0755'

Also, the motivation wasn't clear enough in the commit message to
understand why we need to manage the content of dbpath.