### PR TITLE
fix mongodb_is_master fact

### DIFF
--- a/lib/facter/is_master.rb
+++ b/lib/facter/is_master.rb
@@ -36,8 +36,7 @@ Facter.add('mongodb_is_master') do
       Facter::Core::Execution.exec("mongo --quiet #{mongoPort} --eval \"#{e}printjson(db.adminCommand({ ping: 1 }))\"")
 
       if $?.success?
-        mongo_output = Facter::Core::Execution.exec("mongo --quiet #{mongoPort} --eval \"#{e}printjson(db.isMaster())\"")
-        JSON.parse(mongo_output.gsub(/ISODate\((.+?)\)/, '\1 '))['ismaster'] ||= false
+        Facter::Core::Execution.exec("mongo --quiet #{mongoPort} --eval \"#{e}db.isMaster().ismaster\"")
       else
         'not_responding'
       end


### PR DESCRIPTION
I ran into this error with puppet 4.8.1 and mongodb 2.6.12 (centos 7) if it's a master. the fact worked on non-masters.
```
# facter -p mongodb_is_master
2016-11-26 23:37:31.570886 ERROR puppetlabs.facter - error while resolving custom fact "mongodb_is_master": 757: unexpected token at '{
	"setName" : "rs01",
	"setVersion" : 3,
	"ismaster" : true,
	"secondary" : false,
```

this simplyfies the fact and makes it work on masters and non-masters.

I'm no ruby expert but maybe the ||= false makes it a more robust, maybe keeping that part makes sense..?