### PR TITLE
fix mongo service restarting after changing permissions

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -213,7 +213,7 @@ class mongodb::server::config {
 
     file { $dbpath:
       ensure  => directory,
-      mode    => '0755',
+      mode    => '0644',
       owner   => $user,
       group   => $group,
       require => File[$config],


### PR DESCRIPTION
This patch fixes the bug mentioned in https://tickets.puppetlabs.com/browse/MODULES-3748 which caused the mongo service to be restarted after every run because of assigning strange permissions.