### PR TITLE
Fix mongodb_version facter

### DIFF
--- a/lib/facter/mongodb_version.rb
+++ b/lib/facter/mongodb_version.rb
@@ -2,7 +2,7 @@ Facter.add(:mongodb_version) do
   setcode do
     if Facter::Core::Execution.which('mongo')
       mongodb_version = Facter::Core::Execution.execute('mongo --version 2>&1')
-      %r{^MongoDB shell version: ([\w\.]+)}.match(mongodb_version)[1]
+      %r{^MongoDB shell version:?\s+([\w\.]+)}.match(mongodb_version)[1]
     end
   end
 end


### PR DESCRIPTION
Fixed error mongodb_version facter:
```
Error: Facter: error while resolving custom fact "mongodb_version": undefined method '[]' for nil:NilClas
```
Mongodb shell from official repository:
```
# rpm -qa | grep mongodb-org-shell
mongodb-org-shell-3.4.1-1.el7.x86_64
```
Output shell:
```
# mongo --version 2>&1 
MongoDB shell version v3.4.1
git version: 5e103c4f5583e2566a45d740225dc250baacfbd7
OpenSSL version: OpenSSL 1.0.1e-fips 11 Feb 2013
allocator: tcmalloc
modules: none
build environment:
    distmod: rhel70
    distarch: x86_64
    target_arch: x86_64
```