### PR TITLE
mongodb no longer provides the stable link

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -40,6 +40,10 @@ class mongodb::globals (
 
   # Setup of the repo only makes sense globally, so we are doing it here.
   if($manage_package_repo) {
+    if $use_enterprise_repo == true and $version == undef {
+      fail('You must set mongodb::globals::version when mongodb::globals::use_enterprise_repo is true')
+    }
+
     class { '::mongodb::repo':
       ensure        => present,
       repo_location => $repo_location,

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -13,7 +13,8 @@ class mongodb::repo (
         $location = $repo_location
         $description = 'MongoDB Custom Repository'
       } elsif $mongodb::globals::use_enterprise_repo == true {
-        $location = 'https://repo.mongodb.com/yum/redhat/$releasever/mongodb-enterprise/stable/$basearch/'
+        $mongover = split($version, '[.]')
+        $location = "https://repo.mongodb.com/yum/redhat/\$releasever/mongodb-enterprise/${mongover[0]}.${mongover[1]}/\$basearch/"
         $description = 'MongoDB Enterprise Repository'
       }
       elsif $version and (versioncmp($version, '3.0.0') >= 0) {

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -9,16 +9,17 @@ class mongodb::repo (
 ) inherits mongodb::params {
   case $::osfamily {
     'RedHat', 'Linux': {
+      if $version != undef {
+        $mongover = split($version, '[.]')
+      }
       if ($repo_location != undef){
         $location = $repo_location
         $description = 'MongoDB Custom Repository'
       } elsif $mongodb::globals::use_enterprise_repo == true {
-        $mongover = split($version, '[.]')
         $location = "https://repo.mongodb.com/yum/redhat/\$releasever/mongodb-enterprise/${mongover[0]}.${mongover[1]}/\$basearch/"
         $description = 'MongoDB Enterprise Repository'
       }
       elsif $version and (versioncmp($version, '3.0.0') >= 0) {
-        $mongover = split($version, '[.]')
         $location = $::architecture ? {
           'x86_64' => "http://repo.mongodb.org/yum/redhat/${::operatingsystemmajrelease}/mongodb-org/${mongover[0]}.${mongover[1]}/x86_64/",
           default  => undef


### PR DESCRIPTION
so we need to link directly to the appropriate version dir, fixed it similar as the no enterprise version