### PR TITLE
Ticket/4444 allow hyphen dbname

### DIFF
--- a/lib/puppet/type/mongodb_database.rb
+++ b/lib/puppet/type/mongodb_database.rb
@@ -5,7 +5,7 @@ Puppet::Type.newtype(:mongodb_database) do
 
   newparam(:name, :namevar=>true) do
     desc "The name of the database."
-    newvalues(/^(\w|-)+$/)
+    newvalues(/^[\w-]+$/)
   end
 
   newparam(:tries) do

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -23,7 +23,7 @@ Puppet::Type.newtype(:mongodb_user) do
     defaultto do
       fail("Parameter 'database' must be set") if provider.database == :absent
     end
-    newvalues(/^\w+$/)
+    newvalues(/^[\w-]+$/)
   end
 
   newparam(:tries) do


### PR DESCRIPTION
Ticket: https://tickets.puppetlabs.com/browse/MODULES-4444

Related pull request : https://tickets.puppetlabs.com/browse/MODULES-4444

Short description: From mongodb documentation, hyphens is allowed in dbname; one correction has been made to mongodb_database.rb but there s still a blocking regexp in mongodb_user.rb
The second commit in this pull request is just some cleanup job, the regexp initially used in mongodb_database.rb was using a match group which wasnt used so i switched this to a bracket group.
