### PR TITLE
fix gsub pattern for facter is_master.rb

### DIFF
--- a/lib/facter/is_master.rb
+++ b/lib/facter/is_master.rb
@@ -37,7 +37,7 @@ Facter.add('mongodb_is_master') do
 
       if $?.success?
         mongo_output = Facter::Core::Execution.exec("mongo --quiet #{mongoPort} --eval \"#{e}printjson(db.isMaster())\"")
-        JSON.parse(mongo_output.gsub(/ISODate\((.+?)\)/, '\1 '))['ismaster'] ||= false
+        JSON.parse(mongo_output.gsub(/\w+\(.+?\)/, '"foo"'))['ismaster'] ||= false
       else
         'not_responding'
       end


### PR DESCRIPTION
Replace in json mongo_output all values like "function('something')" with string "foo", because I'm looking for 'ismaster' value only.