### PR TITLE
Fix to allow management of mongo instance on localhost over SSL

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -92,6 +92,10 @@ class Puppet::Provider::Mongodb < Puppet::Provider
       unless ssl_ca.nil?
         args += ['--sslCAFile', ssl_ca]
       end
+
+      if config['bind_ip'] == '127.0.0.1'
+          args.push('--sslAllowInvalidCertificates')
+      end
     end
 
     args += ['--eval', cmd]


### PR DESCRIPTION
This module uses bind_ip to connect and 127.0.0.1 won’t match certs, so we have to allow invalid certs. Otherwise the client distrusts the server and errors out. A more ideal fix would be to allow setting of connection string through the module, this is a quick fix.