### PR TITLE
fix mongodb::globals::pidfilepath usage for debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -153,7 +153,7 @@ class mongodb::params inherits mongodb::globals {
         $mongos_config           = '/etc/mongodb-shard.conf'
         $dbpath                  = '/var/lib/mongodb'
         $logpath                 = '/var/log/mongodb/mongodb.log'
-        $pidfilepath             = '/var/run/mongod.pid'
+        $pidfilepath             = pick($::mongodb::globals::pidfilepath, '/var/run/mongod.pid')
         $bind_ip                 = pick($::mongodb::globals::bind_ip, ['127.0.0.1'])
       } else {
         # although we are living in a free world,


### PR DESCRIPTION
using manage repo -> $::mongodb::globals::pidfilepath has no effect and
the default is used.