### PR TITLE
MODULES-4923: Add "sslMode = requireSSL" if ssl is used

### DIFF
--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -184,6 +184,7 @@ syslog = <%= @syslog %>
 quiet = <%= @quiet %>
 <% end -%>
 <% if @ssl -%>
+sslMode = requireSSL
 sslOnNormalPorts = true
 sslPEMKeyFile = <%= @ssl_key %>
 <% if @ssl_ca -%>


### PR DESCRIPTION
This is needed by the providers, since they check for this key in order
to add the --ssl flag to the commands they execute