### PR TITLE
Revert "Add "sslMode = requireSSL" if ssl is used"

### DIFF
--- a/templates/mongodb.conf.erb
+++ b/templates/mongodb.conf.erb
@@ -184,7 +184,6 @@ syslog = <%= @syslog %>
 quiet = <%= @quiet %>
 <% end -%>
 <% if @ssl -%>
-sslMode = requireSSL
 sslOnNormalPorts = true
 sslPEMKeyFile = <%= @ssl_key %>
 <% if @ssl_ca -%>


### PR DESCRIPTION
sslMode can't be used with sslOnNormalPorts. It'll get the following
error:

    SEVERE: Failed global initialization: BadValue net.ssl.mode is not allowed when net.ssl.sslOnNormalPorts is specified

This reverts commit 1877d30a6db0f19d027071a2939abb6821445839.