### PR TITLE
MODULES-4923: Use sslOnNormalPorts instead of sslMode to determine if ssl is enabled

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -56,7 +56,7 @@ class Puppet::Provider::Mongodb < Puppet::Provider
       config_hash['bindip'] = config['bind_ip']
       config_hash['port'] = config['port']
       config_hash['ipv6'] = config['ipv6']
-      config_hash['ssl'] = config['sslMode']
+      config_hash['ssl'] = config['sslOnNormalPorts']
       config_hash['sslcert'] = config['sslPEMKeyFile']
       config_hash['sslca'] = config['sslCAFile']
       config_hash['auth'] = config['auth']


### PR DESCRIPTION
For the older mongodb config format, sslMode is not used, and thus
enabling SSL is not possible for the providers. So we switch to using
the actual parameter that is used, which is sslOnNormalPorts.

This is where the sslMode is fetched https://github.com/puppetlabs/puppetlabs-mongodb/blob/master/lib/puppet/provider/mongodb.rb#L59

However, the template only sets sslOnNormalPorts https://github.com/puppetlabs/puppetlabs-mongodb/blob/master/templates/mongodb.conf.erb#L187

So lets use that instead of sslMode.