### PR TITLE
Fix Provider db_ismaster

### DIFF
--- a/lib/puppet/provider/mongodb.rb
+++ b/lib/puppet/provider/mongodb.rb
@@ -130,18 +130,13 @@ class Puppet::Provider::Mongodb < Puppet::Provider
   end
 
   def self.db_ismaster
-    cmd_ismaster = 'printjson(db.isMaster())'
+    cmd_ismaster = 'db.isMaster().ismaster'
     if mongorc_file
       cmd_ismaster = mongorc_file + cmd_ismaster
     end
     db = 'admin'
-    out = mongo_cmd(db, get_conn_string, cmd_ismaster)
-    out.gsub!(/ObjectId\(([^)]*)\)/, '\1')
-    out.gsub!(/ISODate\((.+?)\)/, '\1 ')
-    out.gsub!(/^Error\:.+/, '')
-    res = JSON.parse out
-
-    return res['ismaster']
+    res = mongo_cmd(db, get_conn_string, cmd_ismaster).to_s.chomp()
+    res.eql?('true') ? true : false
   end
 
   def db_ismaster


### PR DESCRIPTION
Similar to #348 `lib/puppet/provider/mongodb.rb` in 3.4.4 I get parsing errors for the JSON as additional reg ex is needed.

I was getting errors such as:
```
Error: /Stage[main]/Mongodb::Server/Mongodb::Db[admin]/Mongodb_user[User admin on db admin]/ensure: change from absent to present failed: Could not set 'present' on ensure: 757: unexpected token at '{
 "hosts" : [
  "10.254.1.22:27017",
  "10.254.2.22:27017",
  "10.254.3.22:27017"
 ],
 "setName" : "setname",
 "setVersion" : 6,
 "ismaster" : false,
 "secondary" : true,
 "me" : "10.254.2.22:27017",
 "lastWrite" : {
  "opTime" : {
   "ts" : Timestamp(1495187888, 1),
   "t" : NumberLong(-1)
  },
  "lastWriteDate" : "2017-05-19T09:58:08Z"
 },
 "maxBsonObjectSize" : 16777216,
 "maxMessageSizeBytes" : 48000000,
 "maxWriteBatchSize" : 1000,
 "localTime" : "2017-05-19T09:58:26.460Z" ,
 "maxWireVersion" : 5,
 "minWireVersion" : 0,
 "readOnly" : false,
 "ok" : 1
}
' at 48:/etc/puppet/vendor/modules/mongodb/manifests/db.pp
```

This reduces the complexity, we only need a true/false which is returned as such.