### PR TITLE
Change rescue to allow non IPv4 string

### DIFF
--- a/lib/puppet/util/mongodb_validator.rb
+++ b/lib/puppet/util/mongodb_validator.rb
@@ -20,7 +20,7 @@ module Puppet
           @mongodb_server = IPAddr.new(uri.host).to_s
           @mongodb_port = uri.port
         rescue
-          @mongodb_server = IPAddr.new(mongodb_server).to_s
+          @mongodb_server = mongodb_server.to_s
           @mongodb_port   = mongodb_port
         end
       end


### PR DESCRIPTION
This solves the following error;
   Error: /Stage[main]/Mongodb::Server::Service/Mongodb_conn_validator[mongodb]: Could not evaluate: invalid address

When using the following puppet configuration;
   class { 'mongodb::server':
     bind_ip          => ["$::fqdn"]
   }

Ticket: 
  https://tickets.puppetlabs.com/browse/MODULES-3819