### PR TITLE
Add handle_creds option to class mongodb::server

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,10 @@ Administrator user roles
 ##### `store_creds`
 Store admin credentials in mongorc.js file. Uses with `create_admin` parameter
 
+##### `handle_creds`
+Set this to false to avoid having puppet handle .mongorc.js in case you wish to deliver it by other means.
+This is needed for facts to work if you have auth set to true.  Default is true.
+
 
 #### Class: mongodb::mongos
 class. This class should only be used if you want to implement sharding within

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class mongodb::params inherits mongodb::globals {
   $restart               = true
   $create_admin          = false
   $admin_username        = 'admin'
+  $handle_creds          = true
   $store_creds           = false
   $rcfile                = "${::root_home}/.mongorc.js"
   $dbpath_fix            = true

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -79,6 +79,7 @@ class mongodb::server (
   $create_admin     = $mongodb::params::create_admin,
   $admin_username   = $mongodb::params::admin_username,
   $admin_password   = undef,
+  $handle_creds     = $mongodb::params::handle_creds,
   $store_creds      = $mongodb::params::store_creds,
   $admin_roles      = ['userAdmin', 'readWrite', 'dbAdmin',
                       'dbAdminAnyDatabase', 'readAnyDatabase',

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -25,6 +25,7 @@ class mongodb::server::config {
   $create_admin     = $mongodb::server::create_admin
   $admin_username   = $mongodb::server::admin_username
   $admin_password   = $mongodb::server::admin_password
+  $handle_creds     = $mongodb::server::handle_creds
   $store_creds      = $mongodb::server::store_creds
   $rcfile           = $mongodb::server::rcfile
   $verbose          = $mongodb::server::verbose
@@ -257,17 +258,19 @@ class mongodb::server::config {
     }
   }
 
-  if $auth and $store_creds {
-    file { $rcfile:
-      ensure  => present,
-      content => template('mongodb/mongorc.js.erb'),
-      owner   => 'root',
-      group   => 'root',
-      mode    => '0600',
-    }
-  } else {
-    file { $rcfile:
-      ensure => absent,
+  if $handle_creds {
+    if $auth and $store_creds {
+      file { $rcfile:
+        ensure  => present,
+        content => template('mongodb/mongorc.js.erb'),
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0600',
+      }
+    } else {
+      file { $rcfile:
+        ensure => absent,
+      }
     }
   }
 }


### PR DESCRIPTION
Ticket: https://tickets.puppetlabs.com/browse/MODULES-1754
Topic: After turnining on mongodb auth..subsequent runs fail

Although this is an old ticket the problem still exist in latest mongodb.
If you enable auth you need to store credentials for facts and to make adjustments to your setup.
This fix allows you to distribute mongorc.js manually if you do not want to store credentials in your puppet repository.