### PR TITLE
(maint) fix puppet 5 spec failure

### DIFF
--- a/manifests/mongos/service.pp
+++ b/manifests/mongos/service.pp
@@ -29,27 +29,25 @@ class mongodb::mongos::service (
     $bind_ip_real = $bind_ip
   }
 
-  if $::osfamily == 'RedHat' {
-    file { '/etc/sysconfig/mongos' :
+  if $service_manage {
+    if $::osfamily == 'RedHat' {
+      file { '/etc/sysconfig/mongos' :
+        ensure  => file,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0755',
+        content => 'OPTIONS="--quiet -f /etc/mongodb-shard.conf"',
+        before  => Service['mongos'],
+      }
+    }
+    file { '/etc/init.d/mongos' :
       ensure  => file,
+      content => template("mongodb/mongos/${::osfamily}/mongos.erb"),
       owner   => 'root',
       group   => 'root',
       mode    => '0755',
-      content => 'OPTIONS="--quiet -f /etc/mongodb-shard.conf"',
       before  => Service['mongos'],
     }
-  }
-
-  file { '/etc/init.d/mongos' :
-    ensure  => file,
-    content => template("mongodb/mongos/${::osfamily}/mongos.erb"),
-    owner   => 'root',
-    group   => 'root',
-    mode    => '0755',
-    before  => Service['mongos'],
-  }
-
-  if $service_manage {
     service { 'mongos':
       ensure    => $service_ensure_real,
       name      => $service_name,


### PR DESCRIPTION
for some reason, the test for the mongos service was choking on Puppet 5.0.0 but not Puppet 4.10.1. the config file resources for the mongos service used the 'before' param with value Service['mongos']. This does not appear to work in Puppet 5.0.0 since the service resource wasn't being created if mange_service was false.