### PR TITLE
Allow unencrypted passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -647,8 +647,11 @@ mongodb_user { testuser:
 ##### `username`
 Name of the mongodb user.
 
-##### `password_hash`
-Hex encoded md5 hash of "$username:mongo:$password".
+#####`password_hash`
+Hex encoded md5 hash of "$username:mongo:$password". Only available on MongoDB 3.0 and later.
+
+#####`password`
+Plaintext password of the user.
 
 ##### `database`
 Name of database. It will be created, if not exists.

--- a/lib/puppet/parser/functions/mongodb_password.rb
+++ b/lib/puppet/parser/functions/mongodb_password.rb
@@ -1,4 +1,4 @@
-require 'digest/md5'
+require File.expand_path(File.join(File.dirname(__FILE__),'..','..','util','mongodb_md5er'))
 
 module Puppet::Parser::Functions
   newfunction(:mongodb_password, :type => :rvalue, :doc => <<-EOS
@@ -9,6 +9,6 @@ module Puppet::Parser::Functions
     raise(Puppet::ParseError, 'mongodb_password(): Wrong number of arguments ' +
       "given (#{args.size} for 2)") if args.size != 2
 
-    Digest::MD5.hexdigest("#{args[0]}:mongo:#{args[1]}")
+    Puppet::Util::MongodbMd5er.md5(args[0],args[1])
   end
 end

--- a/lib/puppet/type/mongodb_user.rb
+++ b/lib/puppet/type/mongodb_user.rb
@@ -1,3 +1,4 @@
+require File.expand_path(File.join(File.dirname(__FILE__),'..','util','mongodb_md5er'))
 Puppet::Type.newtype(:mongodb_user) do
   @doc = 'Manage a MongoDB user. This includes management of users password as well as privileges.'
 
@@ -51,11 +52,30 @@ Puppet::Type.newtype(:mongodb_user) do
   end
 
   newproperty(:password_hash) do
-    desc "The password hash of the user. Use mongodb_password() for creating hash."
+    desc "The password hash of the user. Use mongodb_password() for creating hash. Only available on MongoDB 3.0 and later."
     defaultto do
-      fail("Property 'password_hash' must be set. Use mongodb_password() for creating hash.") if provider.database == :absent
+      if @resource[:password].nil?
+        fail("Property 'password_hash' must be set. Use mongodb_password() for creating hash.") if provider.database == :absent
+      end
     end
     newvalue(/^\w+$/)
+  end
+
+  newproperty(:password) do
+    desc "The plaintext password of the user."
+    # magic should/is comparison because mongo only returns hashes, but can only
+    # consume plaintext on pre-3.0
+    def should_to_s(value = @should)
+      # Why is this an array sometimes? Ubuntu 14.04...
+      value = value.first if value.is_a? Array
+      Puppet::Util::MongodbMd5er.md5(@resource[:username],value)
+    end
+    def is_to_s(value = @is)
+      @resource.provider.password_hash
+    end
+    def insync?(is)
+      self.should_to_s == self.is_to_s
+    end
   end
 
   autorequire(:package) do
@@ -64,5 +84,13 @@ Puppet::Type.newtype(:mongodb_user) do
 
   autorequire(:service) do
     'mongodb'
+  end
+
+  validate do
+    if self[:password_hash].nil? and self[:password].nil? and self.provider.password.nil? and self.provider.password_hash.nil?
+      err("Either 'password_hash' or 'password' should be provided")
+    elsif !self[:password_hash].nil? and !self[:password].nil?
+      err("Only one of 'password_hash' or 'password' should be provided")
+    end
   end
 end

--- a/lib/puppet/util/mongodb_md5er.rb
+++ b/lib/puppet/util/mongodb_md5er.rb
@@ -1,0 +1,11 @@
+require 'digest/md5'
+
+module Puppet
+  module Util
+    class MongodbMd5er
+      def self.md5(username,password)
+        Digest::MD5.hexdigest("#{username}:mongo:#{password}")
+      end
+    end
+  end
+end

--- a/manifests/db.pp
+++ b/manifests/db.pp
@@ -35,7 +35,8 @@ define mongodb::db (
 
   mongodb_user { "User ${user} on db ${db_name}":
     ensure        => present,
-    password_hash => $hash,
+    password_hash => $password_hash,
+    password      => $password,
     username      => $user,
     database      => $db_name,
     roles         => $roles,

--- a/spec/acceptance/nodesets/ubuntu-1404-vcloud.yml
+++ b/spec/acceptance/nodesets/ubuntu-1404-vcloud.yml
@@ -1,0 +1,15 @@
+HOSTS:
+  'ubuntu-1404-64':
+    roles:
+      - master
+    platform: ubuntu-14.04-amd64
+    hypervisor: vcloud
+    template: ubuntu-1404-x86_64
+CONFIG:
+  type: foss
+  ssh:
+    keys: "~/.ssh/id_rsa-acceptance"
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/

--- a/spec/unit/puppet/type/mongodb_user_spec.rb
+++ b/spec/unit/puppet/type/mongodb_user_spec.rb
@@ -22,9 +22,14 @@ describe Puppet::Type.type(:mongodb_user) do
     expect(@user[:tries]).to eq(5)
   end
 
-  it 'should accept a password' do
+  it 'should accept a password hash' do
     @user[:password_hash] = 'foo'
     expect(@user[:password_hash]).to eq('foo')
+  end
+
+  it 'should accept a plaintext password' do
+    @user[:password] = 'foo'
+    expect(@user[:password]).to eq('foo')
   end
 
   it 'should use default role' do


### PR DESCRIPTION
Mongo less than 3 have different password interfaces for users than the
providers expose. They have to be set in plaintext and read in md5 form.
This PR adds the plaintext password attribute to the user resource.

#229 rebased