### PR TITLE
replset : retry several times if some members are dead

### DIFF
--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -186,6 +186,8 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, :parent => Puppet::Provider:
       # Find the alive members so we don't try to add dead members to the replset
       retry_limit = 10
       retry_sleep = 3
+      alive_hosts = []
+      dead_hosts = []
       retry_limit.times do |n|
         begin
           alive_hosts = alive_members(@property_flush[:members])

--- a/lib/puppet/provider/mongodb_replset/mongo.rb
+++ b/lib/puppet/provider/mongodb_replset/mongo.rb
@@ -193,14 +193,14 @@ Puppet::Type.type(:mongodb_replset).provide(:mongo, :parent => Puppet::Provider:
           if dead_hosts.empty?
             return
           else
-            Puppet.warn "All members are not ready yet, waiting for #{dead_hosts.inspect}"
+            Puppet.warning "All members are not ready yet, waiting for #{dead_hosts.inspect}"
             sleep retry_sleep
             next
           end
         end
       end
       Puppet.info "Alive members: #{alive_hosts.inspect}"
-      Puppet.warn "Dead members: #{dead_hosts.inspect}" unless dead_hosts.empty?
+      Puppet.warning "Dead members: #{dead_hosts.inspect}" unless dead_hosts.empty?
       raise Puppet::Error, "Can't connect to any member of replicaset #{self.name}." if alive_hosts.empty?
     else
       alive_hosts = []


### PR DESCRIPTION
When then replicationSet is initialized, we should wait for all members
to become alive. This patch will retry 10 times (max) waiting 3 seconds
between each check.